### PR TITLE
Allow keys of every union part to be used in `changedKey`

### DIFF
--- a/create-map/errors.ts
+++ b/create-map/errors.ts
@@ -1,0 +1,13 @@
+import { createMap } from '../index.js'
+
+let test = createMap<
+  { id: string; isLoading: true } | { isLoading: false; a: string; b: number }
+>()
+
+test.subscribe((value, changedKey) => {
+  if (changedKey === 'a') {
+  }
+  // THROWS This condition will always return 'false' since the types '"id" | "b" | "a" | "isLoading" | undefined' and '"c"' have no overlap.
+  if (changedKey === 'c') {
+  }
+})

--- a/create-map/index.d.ts
+++ b/create-map/index.d.ts
@@ -1,3 +1,5 @@
+type AllKeys<T> = T extends any ? keyof T : never
+
 export interface MapStore<Value extends object = any> {
   /**
    * `true` if store has any listeners.
@@ -28,7 +30,7 @@ export interface MapStore<Value extends object = any> {
   subscribe(
     listener: (
       value: Readonly<Value>,
-      changedKey: undefined | keyof Value
+      changedKey: undefined | AllKeys<Value>
     ) => void
   ): () => void
 
@@ -43,7 +45,7 @@ export interface MapStore<Value extends object = any> {
    * @returns Function to remove listener.
    */
   listen(
-    listener: (value: Readonly<Value>, changedKey: keyof Value) => void
+    listener: (value: Readonly<Value>, changedKey: AllKeys<Value>) => void
   ): () => void
 
   /**


### PR DESCRIPTION
Details: https://stackoverflow.com/a/61685380/6540091
This should not lead to any additional errors, because `changedKey` is usually used in comparisons.
