### PR TITLE
add note about nextjs11.1 workaround

### DIFF
--- a/README.md
+++ b/README.md
@@ -619,4 +619,7 @@ module.exports = withTM({
 })
 ```
 
+In Next.js 11.1 you can alternatively use the experimental [`esmExternals`] config option.
+
 [`next-transpile-modules`]: https://www.npmjs.com/package/next-transpile-modules
+[`esmExternals`]: (https://nextjs.org/blog/next-11-1#es-modules-support)


### PR DESCRIPTION
NextJS 11.1 added a flag to enable their (currently experimetal) ESM support. This option is available as a preview for NextJS 12, which will support ESM out of the box.