### PR TITLE
Add type for notify function

### DIFF
--- a/atom/errors.ts
+++ b/atom/errors.ts
@@ -7,9 +7,16 @@ store.listen(value => {
   value.value = 2
 })
 
+store.notify()
+store.notify("value")
+// THROWS Argument of type '"nonExistentKey"' is not assignable to parameter of type '"value" | undefined'.
+store.notify("nonExistentKey")
+
 let fnStore = atom<() => void>(() => {
   fnStore.set(() => {})
 })
 
 let fn = fnStore.get()
 fn()
+
+fnStore.notify()

--- a/atom/index.d.ts
+++ b/atom/index.d.ts
@@ -1,5 +1,7 @@
 import { lastAction } from '../action/index.js'
 
+type AllKeys<T> = T extends any ? keyof T : never
+
 type ReadonlyIfObject<Value> = Value extends undefined
   ? Value
   : Value extends (...args: any) => any
@@ -80,13 +82,21 @@ export interface WritableAtom<Value = any> extends ReadableAtom<Value> {
    * @param newValue New store value.
    */
   set(newValue: Value): void
+
+  /**
+   * Trigger listeners without changing value in the key for performance reasons.
+   *
+   * @param changedKey Key that was changed.
+   * If not provided that means the whole value was changed.
+   */
+  notify(changedKey?: AllKeys<Value>): void
 }
 
 export type Atom<Value = any> = ReadableAtom<Value> | WritableAtom<Value>
 
 /**
  * Create store with atomic value. It could be a string or an object, which you
- * will replace completly.
+ * will replace completely.
  *
  * If you want to change keys in the object inside store, use {@link map}.
  *

--- a/map/index.d.ts
+++ b/map/index.d.ts
@@ -1,10 +1,10 @@
 import type {
   WritableAtom,
   ReadableAtom,
-  ReadonlyIfObject
+  ReadonlyIfObject,
+  AllKeys,
 } from '../atom/index.js'
 
-type AllKeys<T> = T extends any ? keyof T : never
 type Get<T, K extends PropertyKey> = Extract<T, { [K1 in K]: any }>[K]
 
 export type WritableStore<Value = any> =


### PR DESCRIPTION
- [x] Do we allow calling notify without parameter? (See example with function as value)
- [x] Is it for writable stores only?