### PR TITLE
fix: 🔄 PropertyKey => KeyofBase

### DIFF
--- a/map/index.d.ts
+++ b/map/index.d.ts
@@ -5,7 +5,9 @@ import type {
   AllKeys
 } from '../atom/index.js'
 
-type Get<T, K extends PropertyKey> = Extract<T, { [K1 in K]: any }>[K]
+type KeyofBase = keyof any
+
+type Get<T, K extends KeyofBase> = Extract<T, { [K1 in K]: any }>[K]
 
 export type WritableStore<Value = any> =
   | WritableAtom<Value>


### PR DESCRIPTION
* The bug that we found in ts-essentials – https://github.com/krzkaczor/ts-essentials/issues/278#issuecomment-998235314
* The explanation in the release – https://devblogs.microsoft.com/typescript/announcing-typescript-2-9-2/#support-for-symbols-and-numeric-literals-in-keyof-and-mapped-object-types

That's the way how to tolerate `keyofStringsOnly` option in TypeScript