### PR TITLE
docs: remove obsolete link

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,6 @@ export const Admins = () => {
 * [Guide](#guide)
 * Integration
   * [React & Preact](#react--preact)
-  * [Next.js](#nextjs)
   * [Vue](#vue)
   * [Svelte](#svelte)
   * [Vanilla JS](#vanilla-js)


### PR DESCRIPTION
There is no nextjs section so the link should be removed