### PR TITLE
notify: use a listenerQueue for breadth-first instead of depth-first notification propagation

### DIFF
--- a/atom/index.d.ts
+++ b/atom/index.d.ts
@@ -94,6 +94,7 @@ export interface WritableAtom<Value = any> extends ReadableAtom<Value> {
 
 export type Atom<Value = any> = ReadableAtom<Value> | WritableAtom<Value>
 
+export declare let notifyStart:number
 /**
  * Create store with atomic value. It could be a string or an object, which you
  * will replace completely.

--- a/atom/index.js
+++ b/atom/index.js
@@ -1,5 +1,7 @@
 import { clean } from '../clean-stores/index.js'
 
+let listenerQueue = []
+export let notifyStart = 0
 export let atom = initialValue => {
   let currentListeners
   let nextListeners = []
@@ -18,8 +20,16 @@ export let atom = initialValue => {
     },
     notify(changedKey) {
       currentListeners = nextListeners
-      for (let listener of currentListeners) {
-        listener(store.value, changedKey)
+      let runListenerQueue = !listenerQueue.length
+      for (let i = 0; i < currentListeners.length; i++) {
+        listenerQueue.push(currentListeners[i], store.value, changedKey)
+      }
+      if (runListenerQueue) {
+        notifyStart = Date.now()
+        for (let i = 0; i < listenerQueue.length; i+=3) {
+          listenerQueue[i](listenerQueue[i + 1], listenerQueue[i + 2])
+        }
+        listenerQueue.length = 0
       }
     },
     listen(listener) {

--- a/atom/index.js
+++ b/atom/index.js
@@ -1,7 +1,7 @@
 import { clean } from '../clean-stores/index.js'
 
 let listenerQueue = []
-export let notifyStart = 0
+export let notifyId = 0
 export let atom = initialValue => {
   let currentListeners
   let nextListeners = []
@@ -25,7 +25,7 @@ export let atom = initialValue => {
         listenerQueue.push(currentListeners[i], store.value, changedKey)
       }
       if (runListenerQueue) {
-        notifyStart = Date.now()
+        notifyId++
         for (let i = 0; i < listenerQueue.length; i+=3) {
           listenerQueue[i](listenerQueue[i + 1], listenerQueue[i + 2])
         }

--- a/computed/index.js
+++ b/computed/index.js
@@ -1,35 +1,27 @@
 import { onMount } from '../lifecycle/index.js'
-import { atom } from '../atom/index.js'
-
-const collectWritable = deps => [
-  ...new Set(
-    deps.reduce(
-      (acc, dep) => (dep.deps ? [...acc, ...dep.deps] : [...acc, dep]),
-      []
-    )
-  )
-]
+import { atom, notifyStart } from '../atom/index.js'
 
 export let computed = (stores, cb) => {
   if (!Array.isArray(stores)) stores = [stores]
-  let deps = collectWritable(stores)
 
-  let run = () => cb(...stores.map(store => store.get()))
+  let diamondNotifyStart
+  let run = () => {
+    if (diamondNotifyStart !== notifyStart) {
+      diamondNotifyStart = notifyStart
+      derived.set(cb(...stores.map(store => store.get())))
+    }
+  }
   let derived = atom()
 
   onMount(derived, () => {
-    derived.set(run())
-    let unbinds = deps.map(store =>
-      store.listen(() => {
-        derived.set(run())
-      })
+    let unbinds = stores.map(store =>
+      store.listen(run, cb)
     )
+    run()
     return () => {
       for (let unbind of unbinds) unbind()
     }
   })
-
-  derived.deps = deps
 
   return derived
 }

--- a/computed/index.js
+++ b/computed/index.js
@@ -1,13 +1,13 @@
 import { onMount } from '../lifecycle/index.js'
-import { atom, notifyStart } from '../atom/index.js'
+import { atom, notifyId } from '../atom/index.js'
 
 export let computed = (stores, cb) => {
   if (!Array.isArray(stores)) stores = [stores]
 
-  let diamondNotifyStart
+  let diamondNotifyId
   let run = () => {
-    if (diamondNotifyStart !== notifyStart) {
-      diamondNotifyStart = notifyStart
+    if (diamondNotifyId !== notifyId) {
+      diamondNotifyId = notifyId
       derived.set(cb(...stores.map(store => store.get())))
     }
   }

--- a/computed/index.test.ts
+++ b/computed/index.test.ts
@@ -32,12 +32,10 @@ test('converts stores values', () => {
   equal(value, 'a 0')
   equal(renders, 1)
 
-  clock.now = 100
   letter.set({ letter: 'b' })
   equal(value, 'b 0')
   equal(renders, 2)
 
-  clock.now = 200
   number.set({ number: 1 })
   equal(value, 'b 1')
   equal(renders, 3)
@@ -80,7 +78,6 @@ test('prevents diamond dependency problem', () => {
 
   equal(values, ['a0b0'])
 
-  clock.now = 100
   store.set(1)
   equal(values, ['a0b0', 'a1b1'])
 


### PR DESCRIPTION
fix: store.off() can cause listeners to be out of order

fixes https://github.com/nanostores/nanostores/issues/101