### PR TITLE
Update Svelte store contract link

### DIFF
--- a/README.md
+++ b/README.md
@@ -498,7 +498,7 @@ to get store’s value and re-render component on store’s changes.
 ### Svelte
 
 Every store implements
-[Svelte store contract](https://svelte.dev/docs#Store_contract).
+[Svelte's store contract](https://svelte.dev/docs#component-format-script-4-prefix-stores-with-$-to-access-their-values-store-contract).
 Put `$` before store variable to get store’s
 value and subscribe for store’s changes.
 


### PR DESCRIPTION
The old link went to the top of the page because the id of the header was changed. This PR resolves that.