### PR TITLE
ReadonlyIfObject: Primitive opaque types are not Readonly

### DIFF
--- a/atom/index.d.ts
+++ b/atom/index.d.ts
@@ -2,9 +2,13 @@ import { lastAction } from '../action/index.js'
 
 export type AllKeys<T> = T extends any ? keyof T : never
 
+type Primitive = boolean | number | string
+
 export type ReadonlyIfObject<Value> = Value extends undefined
   ? Value
   : Value extends (...args: any) => any
+  ? Value
+  : Value extends Primitive
   ? Value
   : Value extends object
   ? Readonly<Value>

--- a/atom/index.test.ts
+++ b/atom/index.test.ts
@@ -295,4 +295,16 @@ test('does not mutate listeners while change event', () => {
   equal(events, ['a1', 'b1', 'a2', 'c2'])
 })
 
+declare const scoreSym:unique symbol
+export type scoreType = number&{ [scoreSym]:any }
+
+test('primitive opaque types are not Readonly for subscribe & listen', () => {
+  let parent = atom<scoreType>(1 as scoreType)
+  parent.subscribe($=>{
+    // This has a TS2322 error if $ is Readonly
+    $ = 1 as scoreType
+    return $ + 1
+  })
+})
+
 test.run()


### PR DESCRIPTION
Fixes [issues/130](https://github.com/nanostores/nanostores/issues/130)