### PR TITLE
Added lit docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -528,21 +528,21 @@ Use [`@nanostores/lit`] and `StoreController` reactive controller
 to get store’s value and re-render component on store’s changes.
 
 ```ts
-import { StoreController } from '@nanostores/lit';
+import { StoreController } from '@nanostores/lit'
 import { profile } from '../stores/profile.js'
 import { Post } from '../stores/post.js'
 
 @customElement('my-header')
 class MyElement extends LitElement {
   @property()
-  postId = "1";
+  postId = "1"
 
-  private userController = new StoreController(this, profile);
-  private postController = new StoreController(this, Post(this.postId));
+  private userController = new StoreController(this, profile)
+  private postController = new StoreController(this, Post(this.postId))
     render() {
-      const user = userController.value;
-      const post = postController.value;
-      return html\`<header>${post.title} for ${user.name}</header>`;
+      const user = userController.value
+      const post = postController.value
+      return html\`<header>${post.title} for ${user.name}</header>`
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ export const Admins = () => {
   * [Vue](#vue)
   * [Svelte](#svelte)
   * [Solid](#solid)
+  * [Lit](#lit)
   * [Vanilla JS](#vanilla-js)
   * [Server-Side Rendering](#server-side-rendering)
   * [Tests](#tests)

--- a/README.md
+++ b/README.md
@@ -522,6 +522,32 @@ export function Header({ postId }) {
 
 [`@nanostores/solid`]: https://github.com/nanostores/solid
 
+### Lit
+
+Use [`@nanostores/lit`] and `StoreController` reactive controller
+to get store’s value and re-render component on store’s changes.
+
+```ts
+import { StoreController } from '@nanostores/lit';
+import { profile } from '../stores/profile.js'
+import { Post } from '../stores/post.js'
+
+@customElement('my-header')
+class MyElement extends LitElement {
+  @property()
+  postId = "1";
+
+  private userController = new StoreController(this, profile);
+  private postController = new StoreController(this, Post(this.postId));
+    render() {
+      const user = userController.value;
+      const post = postController.value;
+      return html\`<header>${post.title} for ${user.name}</header>`;
+    }
+}
+```
+
+[`@nanostores/lit`]: https://github.com/nanostores/lit
 
 ### Vanilla JS
 


### PR DESCRIPTION
@ai 

I added a section in the readme for the lit integration we have been talking about in #95. It only covers the most simple way to use it with the reactive controllers directly and I just used the example from the Solid integration above.

However, I don't think we should merge this just yet. The code is not published to npm (I don't think I can publish to the nanostores npm space?) and the lit integration repository is still private in the nanostores GitHub organization.