### PR TITLE
skipping extra computation calls (for diamond problem)

### DIFF
--- a/computed/index.js
+++ b/computed/index.js
@@ -1,6 +1,8 @@
 import { onMount } from '../lifecycle/index.js'
 import { atom, notifyId } from '../atom/index.js'
 
+let callStack = [];
+
 export let computed = (stores, cb) => {
   if (!Array.isArray(stores)) stores = [stores]
 
@@ -20,9 +22,25 @@ export let computed = (stores, cb) => {
   let derived = atom()
 
   onMount(derived, () => {
-    let unbinds = stores.map(store =>
-      store.listen(run, cb)
-    )
+    let callCount = 0;
+    let unbinds
+    if (stores.length > 1) {
+      unbinds = stores.map(store =>
+        store.listen(() => {
+          callCount++
+          setTimeout(() => {
+            if (callCount > 0) {
+              callCount = 0;
+              run()
+            }
+          }, 0)
+        })
+      )
+    } else {
+      unbinds = stores.map(store =>
+        store.listen(run)
+      )
+    }
     run()
     return () => {
       for (let unbind of unbinds) unbind()

--- a/computed/index.js
+++ b/computed/index.js
@@ -1,8 +1,6 @@
 import { onMount } from '../lifecycle/index.js'
 import { atom, notifyId } from '../atom/index.js'
 
-let callStack = [];
-
 export let computed = (stores, cb) => {
   if (!Array.isArray(stores)) stores = [stores]
 


### PR DESCRIPTION
In an example like this
`var a = computed([a, b], (a, b) => a + b);`
2 computation calls are possible
1. when `a` has changed
2. when `b` has changed
in diamond structure, both of the calls can be called altogether

In the proposed change, the computation is deferred with `setTimeout(..., 0)` and then the computation will be triggered only once. It may solve the diamond issue in a simple scenario. #135 (I added the test case this issue) and also `clock.runAll()` is need to be called in some tests

I believe in the current reactive archetype of nanostores completely solving of the diamond problem is not possible. Maybe it's not worth it at all.