### PR TITLE
Introduce level property to allow sorting of stores in computed

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A tiny state manager for **React**, **React Native**, **Preact**, **Vue**,
 **Svelte**, and vanilla JS. It uses **many atomic stores**
 and direct manipulation.
 
-* **Small.** Between 266 and 969 bytes (minified and gzipped).
+* **Small.** Between 275 and 1011 bytes (minified and gzipped).
   Zero dependencies. It uses [Size Limit] to control size.
 * **Fast.** With small atomic and derived stores, you do not need to call
   the selector function for all components on every store change.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A tiny state manager for **React**, **React Native**, **Preact**, **Vue**,
 **Svelte**, and vanilla JS. It uses **many atomic stores**
 and direct manipulation.
 
-* **Small.** Between 275 and 1011 bytes (minified and gzipped).
+* **Small.** Between 318 and 1050 bytes (minified and gzipped).
   Zero dependencies. It uses [Size Limit] to control size.
 * **Fast.** With small atomic and derived stores, you do not need to call
   the selector function for all components on every store change.

--- a/atom/index.js
+++ b/atom/index.js
@@ -4,11 +4,12 @@ let listenerQueue = []
 
 export let notifyId = 0
 
-export let atom = initialValue => {
+export let atom = (initialValue, level) => {
   let currentListeners
   let nextListeners = []
   let store = {
     lc: 0,
+    level: level || 0,
     value: initialValue,
     set(data) {
       store.value = data

--- a/atom/index.js
+++ b/atom/index.js
@@ -24,36 +24,55 @@ export let atom = (initialValue, level) => {
     notify(changedKey) {
       currentListeners = nextListeners
       let runListenerQueue = !listenerQueue.length
-      for (let i = 0; i < currentListeners.length; i++) {
-        listenerQueue.push(currentListeners[i], store.value, changedKey)
+      for (let i = 0; i < currentListeners.length; i += 2) {
+        listenerQueue.push(
+          currentListeners[i],
+          store.value,
+          changedKey,
+          currentListeners[i + 1]
+        )
       }
+
       if (runListenerQueue) {
         notifyId++
-        for (let i = 0; i < listenerQueue.length; i += 3) {
-          listenerQueue[i](listenerQueue[i + 1], listenerQueue[i + 2])
+        let currentLevel = 0
+        for (let i = 0; i < listenerQueue.length; i += 4) {
+          if (listenerQueue[i + 3] - currentLevel > 1) {
+            listenerQueue.push(
+              listenerQueue[i],
+              listenerQueue[i + 1],
+              listenerQueue[i + 2],
+              listenerQueue[i + 3]
+            )
+          } else {
+            listenerQueue[i](listenerQueue[i + 1], listenerQueue[i + 2])
+            currentLevel = listenerQueue[i + 3]
+          }
         }
         listenerQueue.length = 0
       }
     },
-    listen(listener) {
+    listen(listener, listenerLevel) {
       if (nextListeners === currentListeners) {
         nextListeners = nextListeners.slice()
       }
-      store.lc = nextListeners.push(listener)
+
+      store.lc = nextListeners.push(listener, listenerLevel || store.level) / 2
+
       return () => {
         if (nextListeners === currentListeners) {
           nextListeners = nextListeners.slice()
         }
         let index = nextListeners.indexOf(listener)
         if (~index) {
-          nextListeners.splice(index, 1)
+          nextListeners.splice(index, 2)
           store.lc--
           if (!store.lc) store.off()
         }
       }
     },
-    subscribe(cb) {
-      let unbind = store.listen(cb)
+    subscribe(cb, listenerLevel) {
+      let unbind = store.listen(cb, listenerLevel)
       cb(store.value)
       return unbind
     },

--- a/computed/index.js
+++ b/computed/index.js
@@ -4,6 +4,8 @@ import { atom, notifyId } from '../atom/index.js'
 export let computed = (stores, cb) => {
   if (!Array.isArray(stores)) stores = [stores]
 
+  stores.sort((a, b) => b.level - a.level)
+
   let diamondNotifyId
   let diamondArgs = []
   let run = () => {
@@ -17,7 +19,7 @@ export let computed = (stores, cb) => {
       derived.set(cb(...args))
     }
   }
-  let derived = atom()
+  let derived = atom(undefined, stores[0].level + 1)
 
   onMount(derived, () => {
     let unbinds = stores.map(store =>

--- a/computed/index.js
+++ b/computed/index.js
@@ -4,8 +4,6 @@ import { atom, notifyId } from '../atom/index.js'
 export let computed = (stores, cb) => {
   if (!Array.isArray(stores)) stores = [stores]
 
-  stores.sort((a, b) => b.level - a.level)
-
   let diamondNotifyId
   let diamondArgs = []
   let run = () => {
@@ -19,12 +17,11 @@ export let computed = (stores, cb) => {
       derived.set(cb(...args))
     }
   }
-  let derived = atom(undefined, stores[0].level + 1)
+  let sortedStores = stores.slice().sort((a, b) => b.level - a.level)
+  let derived = atom(undefined, sortedStores[0].level + 1)
 
   onMount(derived, () => {
-    let unbinds = stores.map(store =>
-      store.listen(run, cb)
-    )
+    let unbinds = sortedStores.map(store => store.listen(run, cb))
     run()
     return () => {
       for (let unbind of unbinds) unbind()

--- a/computed/index.js
+++ b/computed/index.js
@@ -17,11 +17,10 @@ export let computed = (stores, cb) => {
       derived.set(cb(...args))
     }
   }
-  let sortedStores = stores.slice().sort((a, b) => b.level - a.level)
-  let derived = atom(undefined, sortedStores[0].level + 1)
+  let derived = atom(undefined, Math.max(...stores.map(s => s.level)) + 1)
 
   onMount(derived, () => {
-    let unbinds = sortedStores.map(store => store.listen(run, cb))
+    let unbinds = stores.map(store => store.listen(run, derived.level))
     run()
     return () => {
       for (let unbind of unbinds) unbind()

--- a/computed/index.test.ts
+++ b/computed/index.test.ts
@@ -68,18 +68,22 @@ test('prevents diamond dependency problem', () => {
   let store = atom<number>(0)
   let values: string[] = []
 
-  let a = computed(store, count => `a${count}`)
-  let b = computed(store, count => `b${count}`)
-  let combined = computed([a, b], (first, second) => `${first}${second}`)
+  let a = computed(store, count => count)
+  let b = computed(store, count => count)
+  let c = computed(b, count => count)
+  let combined = computed(
+    [a, b, c],
+    (first, second, third) => `${first}${second}${third}`
+  )
 
   let unsubscribe = combined.subscribe(v => {
     values.push(v)
   })
 
-  equal(values, ['a0b0'])
+  equal(values, ['000'])
 
   store.set(1)
-  equal(values, ['a0b0', 'a1b1'])
+  equal(values, ['000', '111'])
 
   unsubscribe()
 })

--- a/computed/index.test.ts
+++ b/computed/index.test.ts
@@ -2,7 +2,13 @@ import FakeTimers, { InstalledClock } from '@sinonjs/fake-timers'
 import { equal, ok } from 'uvu/assert'
 import { test } from 'uvu'
 
-import { StoreValue, computed, onMount, atom, STORE_UNMOUNT_DELAY } from '../index.js'
+import {
+  StoreValue,
+  computed,
+  onMount,
+  atom,
+  STORE_UNMOUNT_DELAY
+} from '../index.js'
 
 let clock: InstalledClock
 
@@ -64,28 +70,134 @@ test('works with single store', () => {
   unbind()
 })
 
-test('prevents diamond dependency problem', () => {
+let replacer =
+  (...args: [string, string]) =>
+  (v: string) =>
+    v.replace(...args)
+
+test('prevents diamond dependency problem 1', () => {
   let store = atom<number>(0)
   let values: string[] = []
 
-  let a = computed(store, count => `a${count}`)
-  let b = computed(store, count => `b${count}`)
-  let c = computed(b, count => count.replace('b', 'c'))
+  let a = computed(store, v => `a${v}`)
+  let b = computed(a, replacer('a', 'b'))
+  let c = computed(a, replacer('a', 'c'))
+  let d = computed(a, replacer('a', 'd'))
+
+  let combined = computed([b, c, d], ($b, $c, $d) => `${$b}${$c}${$d}`)
+
+  let unsubscribe = combined.subscribe(v => {
+    values.push(v)
+  })
+
+  equal(values, ['b0c0d0'])
+
+  store.set(1)
+  store.set(2)
+
+  equal(values, ['b0c0d0', 'b1c1d1', 'b2c2d2'])
+
+  unsubscribe()
+})
+
+test('prevents diamond dependency problem 2', () => {
+  let store = atom<number>(0)
+  let values: string[] = []
+
+  let a = computed(store, v => `a${v}`)
+  let b = computed(a, replacer('a', 'b'))
+  let c = computed(b, replacer('b', 'c'))
+  let d = computed(c, replacer('c', 'd'))
+  let e = computed(d, replacer('d', 'e'))
+
+  let combined = computed([a, e], (...args) => args.join(''))
+
+  let unsubscribe = combined.subscribe(v => {
+    values.push(v)
+  })
+
+  equal(values, ['a0e0'])
+
+  store.set(1)
+  equal(values, ['a0e0', 'a1e1'])
+
+  unsubscribe()
+})
+
+test('prevents diamond dependency problem 3', () => {
+  let store = atom<number>(0)
+  let values: string[] = []
+
+  let a = computed(store, $store => `a${$store}`)
+  let b = computed(a, replacer('a', 'b'))
+  let c = computed(b, replacer('b', 'c'))
+  let d = computed(c, replacer('c', 'd'))
+
   let combined = computed(
-    [a, b, c],
-    (first, second, third) => `${first}${second}${third}`
+    [a, b, c, d],
+    ($a, $b, $c, $d) => `${$a}${$b}${$c}${$d}`
   )
 
   let unsubscribe = combined.subscribe(v => {
     values.push(v)
   })
 
-  equal(values, ['a0b0c0'])
+  equal(values, ['a0b0c0d0'])
 
   store.set(1)
-  equal(values, ['a0b0c0', 'a1b1c1'])
+  equal(values, ['a0b0c0d0', 'a1b1c1d1'])
 
   unsubscribe()
+})
+
+test('prevents diamond dependency problem 4 (complex)', () => {
+  let store1 = atom<number>(0)
+  let store2 = atom<number>(0)
+  let values: string[] = []
+
+  let fn =
+    (name: string) =>
+    (...v: (string | number)[]) =>
+      `${name}${v.join('')}`
+
+  let a = computed(store1, fn('a'))
+  let b = computed(store2, fn('b'))
+
+  let c = computed([a, b], fn('c'))
+  let d = computed(a, fn('d'))
+
+  let e = computed([c, d], fn('e'))
+
+  let f = computed(e, fn('f'))
+  let g = computed(f, fn('g'))
+
+  let combined1 = computed(e, (...args) => args.join(''))
+  let combined2 = computed([e, g], (...args) => args.join(''))
+
+  let unsubscribe1 = combined1.subscribe(v => {
+    values.push(v)
+  })
+
+  let unsubscribe2 = combined2.subscribe(v => {
+    values.push(v)
+  })
+
+  equal(values, ['eca0b0da0', 'eca0b0da0gfeca0b0da0'])
+
+  store1.set(1)
+  store2.set(2)
+
+  equal(values, [
+    'eca0b0da0',
+    'eca0b0da0gfeca0b0da0',
+    'eca1b0da1',
+    'eca1b0da1gfeca1b0da1',
+    'eca1b2da1',
+    'eca1b2da1gfeca1b2da1'
+  ])
+
+  unsubscribe1()
+  unsubscribe2()
 })
 
 test('prevents dependency listeners from being out of order', () => {
@@ -98,7 +210,7 @@ test('prevents dependency listeners from being out of order', () => {
   })
 
   equal(b.get(), '0ab')
-  let values:string[] = []
+  let values: string[] = []
   let unsubscribe = b.subscribe($b => values.push($b))
   equal(values, ['0ab'])
 
@@ -113,17 +225,17 @@ test('prevents dependency listeners from being out of order', () => {
 test('notifies when stores change within the same notifyId', () => {
   let val$ = atom(1)
 
-  let computed1$ = computed(val$, (val) => {
+  let computed1$ = computed(val$, val => {
     return val
   })
 
-  let computed2$ = computed(computed1$, (computed1) => {
+  let computed2$ = computed(computed1$, computed1 => {
     return computed1
   })
 
-  let events:any[] = []
-  val$.subscribe((val) => events.push({ val }))
-  computed2$.subscribe((computed2) => {
+  let events: any[] = []
+  val$.subscribe(val => events.push({ val }))
+  computed2$.subscribe(computed2 => {
     events.push({ computed2 })
     if (computed2 % 2 === 1) {
       val$.set(val$.get() + 1)
@@ -134,8 +246,14 @@ test('notifies when stores change within the same notifyId', () => {
 
   val$.set(3)
   equal(events, [
-    { val: 1 }, { computed2: 1 }, { val: 2 }, { computed2: 2 },
-    { val: 3 }, { computed2: 3 }, { val: 4 }, { computed2: 4 }
+    { val: 1 },
+    { computed2: 1 },
+    { val: 2 },
+    { computed2: 2 },
+    { val: 3 },
+    { computed2: 3 },
+    { val: 4 },
+    { computed2: 4 }
   ])
 })
 

--- a/computed/index.test.ts
+++ b/computed/index.test.ts
@@ -68,9 +68,9 @@ test('prevents diamond dependency problem', () => {
   let store = atom<number>(0)
   let values: string[] = []
 
-  let a = computed(store, count => count)
-  let b = computed(store, count => count)
-  let c = computed(b, count => count)
+  let a = computed(store, count => `a${count}`)
+  let b = computed(store, count => `b${count}`)
+  let c = computed(b, count => count.replace('b', 'c'))
   let combined = computed(
     [a, b, c],
     (first, second, third) => `${first}${second}${third}`
@@ -80,10 +80,10 @@ test('prevents diamond dependency problem', () => {
     values.push(v)
   })
 
-  equal(values, ['000'])
+  equal(values, ['a0b0c0'])
 
   store.set(1)
-  equal(values, ['000', '111'])
+  equal(values, ['a0b0c0', 'a1b1c1'])
 
   unsubscribe()
 })

--- a/lifecycle/index.js
+++ b/lifecycle/index.js
@@ -135,12 +135,12 @@ export let onMount = (store, initialize) => {
   }
   return on(store, listener, MOUNT, runListeners => {
     let originListen = store.listen
-    store.listen = arg => {
+    store.listen = (...args) => {
       if (!store.lc && !store.active) {
         store.active = true
         runListeners()
       }
-      return originListen(arg)
+      return originListen(...args)
     }
 
     let originOff = store.off

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nanostores",
   "version": "0.7.1",
-  "description": "A tiny (275 bytes) state manager for React/Preact/Vue/Svelte with many atomic tree-shakable stores",
+  "description": "A tiny (318 bytes) state manager for React/Preact/Vue/Svelte with many atomic tree-shakable stores",
   "keywords": [
     "store",
     "state",
@@ -102,21 +102,21 @@
       "import": {
         "./index.js": "{ atom }"
       },
-      "limit": "275 B"
+      "limit": "318 B"
     },
     {
       "name": "Map Template",
       "import": {
         "./index.js": "{ mapTemplate }"
       },
-      "limit": "709 B"
+      "limit": "760 B"
     },
     {
       "name": "All",
       "import": {
         "./index.js": "{ mapTemplate, computed, action, actionFor }"
       },
-      "limit": "1020 B"
+      "limit": "1050 B"
     }
   ],
   "clean-publish": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nanostores",
   "version": "0.7.1",
-  "description": "A tiny (266 bytes) state manager for React/Preact/Vue/Svelte with many atomic tree-shakable stores",
+  "description": "A tiny (275 bytes) state manager for React/Preact/Vue/Svelte with many atomic tree-shakable stores",
   "keywords": [
     "store",
     "state",
@@ -102,21 +102,21 @@
       "import": {
         "./index.js": "{ atom }"
       },
-      "limit": "266 B"
+      "limit": "275 B"
     },
     {
       "name": "Map Template",
       "import": {
         "./index.js": "{ mapTemplate }"
       },
-      "limit": "694 B"
+      "limit": "709 B"
     },
     {
       "name": "All",
       "import": {
         "./index.js": "{ mapTemplate, computed, action, actionFor }"
       },
-      "limit": "968 B"
+      "limit": "1008 B"
     }
   ],
   "clean-publish": {

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
       "import": {
         "./index.js": "{ mapTemplate, computed, action, actionFor }"
       },
-      "limit": "1008 B"
+      "limit": "1020 B"
     }
   ],
   "clean-publish": {


### PR DESCRIPTION
Let's consider following example: 

```
let a = atom(0)
let b = computed(a, v => v)
let c = computed(b, v => v)
let d = computed([b, c], (b, c) => `${b} ${c}`)

d.subscribe((v) => {
  console.log('d', v);
});
```

The example above has following structure: `A -> B, B -> C, BC -> D`

It turns out that the problem is caused by the order in which listeners are added to the `b` store. The order of listeners follows the order of stores, passed to `d`. Since in the array `[b, c]` `b` comes first, `d` subscribes to `b`, then to `c`, and only then `c` subscribes to `b`. So `b` will notify `d` before `c`. Passing `[c, b]` solves the problem.

Letting users to manage the order of stores might not be the best option, since the relations between stores can be tricky and will cause bugs.

In my proposed solution I added to `atom` a new property `level`. Using `level` the computed store can sort passed stores in descending order and subscribe to them in the right order.

I also extended the test for the diamond problem, now it handles both `A -> B, A -> C, BC -> D` and `A -> B, B -> C, BC -> D` cases.

Intuition tells me that there might be more elegant solutions for the problem, especially using `notifyId` and `listenerQueue`.  I hope at least my explanation of the issue will be useful.