### PR TITLE
Update the setKey type to allow pass undefined as value

### DIFF
--- a/map/index.d.ts
+++ b/map/index.d.ts
@@ -94,7 +94,7 @@ export interface MapStore<Value extends object = any>
    */
   setKey<Key extends AllKeys<Value>>(
     key: Key,
-    value: Get<Value, Key> | Value[Key]
+    value: Get<Value, Key> | Value[Key] | undefined
   ): void
 }
 


### PR DESCRIPTION
Based on the setKey code, if you pass undefined as a value into it, the field is deleted. That's why we should allow undefined to be passed as a value in types.

https://github.com/nanostores/nanostores/blob/5b0949d27741a4f9c1390bbca7f2a3a73de54e69/map/index.js#L10