### PR TITLE
Updating TS signatures for map-alike stores

### DIFF
--- a/listen-keys/errors.ts
+++ b/listen-keys/errors.ts
@@ -1,0 +1,22 @@
+import { listenKeys } from './index.js'
+import { map, WritableAtom } from '../index.js'
+
+type TestType =
+  | { id: string; isLoading: true }
+  | { isLoading: false; a: string; b: number; c?: number }
+
+let test = map<TestType>()
+
+listenKeys(test, ['a', 'b', 'c'], () => {})
+
+// THROWS is not assignable
+listenKeys(test, ['unknownKey'], () => {})
+
+declare let fakeStore: {
+  setKey: (key: 'hey' | 'you', value?: boolean | string) => void
+} & WritableAtom<null>
+
+listenKeys(fakeStore, ['hey', 'you'], () => {})
+
+// THROWS is not assignable
+listenKeys(fakeStore, ['unknownKey'], () => {})

--- a/map/errors.ts
+++ b/map/errors.ts
@@ -1,18 +1,10 @@
 import { map } from '../index.js'
-import type { AllSubscribableKeys } from './index'
 
 type TestType =
   | { id: string; isLoading: true }
   | { isLoading: false; a: string; b: number; c?: number }
 
-type Eq<T1, T2> = T1 extends T2 ? true : false
-type Assert<V extends true> = V
-
 let test = map<TestType>()
-
-type K1 = Assert<
-  Eq<AllSubscribableKeys<typeof test>, 'id' | 'isLoading' | 'a' | 'b' | 'c'>
->
 
 test.subscribe((_, changedKey) => {
   if (changedKey === 'a') {
@@ -42,9 +34,3 @@ test.setKey('a', 'string')
 test.setKey('b', 5)
 // THROWS Argument of type '"z"' is not assignable to parameter
 test.setKey('z', '123')
-
-type AcceptableKeys = 'hey' | 'you'
-declare const fakeStore: {
-  setKey: (key: AcceptableKeys, value?: boolean | string) => void
-}
-type K2 = Assert<Eq<AllSubscribableKeys<typeof fakeStore>, AcceptableKeys>>

--- a/map/errors.ts
+++ b/map/errors.ts
@@ -1,10 +1,18 @@
 import { map } from '../index.js'
+import type { AllSubscribableKeys } from './index'
 
 type TestType =
   | { id: string; isLoading: true }
   | { isLoading: false; a: string; b: number; c?: number }
 
+type Eq<T1, T2> = T1 extends T2 ? true : false
+type Assert<V extends true> = V
+
 let test = map<TestType>()
+
+type K1 = Assert<
+  Eq<AllSubscribableKeys<typeof test>, 'id' | 'isLoading' | 'a' | 'b' | 'c'>
+>
 
 test.subscribe((_, changedKey) => {
   if (changedKey === 'a') {
@@ -34,3 +42,9 @@ test.setKey('a', 'string')
 test.setKey('b', 5)
 // THROWS Argument of type '"z"' is not assignable to parameter
 test.setKey('z', '123')
+
+type AcceptableKeys = 'hey' | 'you'
+declare const fakeStore: {
+  setKey: (key: AcceptableKeys, value?: boolean | string) => void
+}
+type K2 = Assert<Eq<AllSubscribableKeys<typeof fakeStore>, AcceptableKeys>>

--- a/map/index.d.ts
+++ b/map/index.d.ts
@@ -18,7 +18,7 @@ export type AllSubscribableKeys<T> = T extends {
   setKey: (key: infer K, ...args: any[]) => any
 }
   ? K
-  : AllKeys<T>
+  : AllKeys<StoreValue<T>>
 
 export type WritableStore<Value = any> =
   | WritableAtom<Value>
@@ -35,10 +35,10 @@ export type StoreValue<SomeStore> = SomeStore extends {
   : any
 
 // Basic contract for map-alike stores
-export type BaseMapStore<Value = any> = Store<Value> & {
-  setKey: (key: any, value: any) => void
+export type BaseMapStore<Value = any> = WritableAtom<Value> & {
+  setKey: (key: any, value: any) => any
 }
-export type MapStoreKeys<TheStore> = AllSubscribableKeys<StoreValue<TheStore>>
+export type MapStoreKeys<TheStore> = AllSubscribableKeys<TheStore>
 
 export interface MapStore<Value extends object = any>
   extends WritableAtom<Value> {
@@ -60,7 +60,7 @@ export interface MapStore<Value extends object = any>
   subscribe(
     listener: (
       value: ReadonlyIfObject<Value>,
-      changedKey: undefined | AllSubscribableKeys<Value>
+      changedKey: undefined | AllKeys<Value>
     ) => void
   ): () => void
 
@@ -77,7 +77,7 @@ export interface MapStore<Value extends object = any>
   listen(
     listener: (
       value: ReadonlyIfObject<Value>,
-      changedKey: AllSubscribableKeys<Value>
+      changedKey: AllKeys<Value>
     ) => void
   ): () => void
 


### PR DESCRIPTION
The basic idea is quite simple:

1. we establish a contract, that anything that complies with the signature `{ setKey: (key: any, value: any) => void }` can in fact work with `listenKeys`
2. we make a new generic helper that infers possible key values based on this contract. This is used in `listenKeys` and can then be imported in react/preact/solid/vue types as well.

This will play well with nanoform and, possibly, other custom map-based implementations.