### PR TITLE
Check referential equality before notifying

### DIFF
--- a/action/index.test.ts
+++ b/action/index.test.ts
@@ -6,7 +6,7 @@ import { lastAction, onNotify, allTasks, action, atom } from '../index.js'
 
 test('shows action name', () => {
   let events: (string | undefined)[] = []
-  let store = atom(1)
+  let store = atom(0)
 
   onNotify(store, () => {
     events.push(store[lastAction])
@@ -45,14 +45,14 @@ test('supports async tasks', async () => {
   equal(await increaseWithDelay(), 'result')
   equal(counter.get(), 2)
 
-  counter.set(2)
+  counter.set(3)
 
   equal(events, ['increaseWithDelay', 'increaseWithDelay', undefined])
 })
 
 test('track previous actionName correctly', () => {
   let events: (string | undefined)[] = []
-  let store = atom(1)
+  let store = atom(0)
 
   onNotify(store, () => {
     events.push(store[lastAction])

--- a/atom/index.js
+++ b/atom/index.js
@@ -12,8 +12,10 @@ export let atom = (initialValue, level) => {
     l: level || 0,
     value: initialValue,
     set(data) {
-      store.value = data
-      store.notify()
+      if (store.value !== data) {
+        store.value = data
+        store.notify()
+      }
     },
     get() {
       if (!store.lc) {

--- a/atom/index.test.ts
+++ b/atom/index.test.ts
@@ -295,4 +295,24 @@ test('does not mutate listeners while change event', () => {
   equal(events, ['a1', 'b1', 'a2', 'c2'])
 })
 
+test('prevents notifying when new value is referentially equal to old one', () => {
+  let events: (string | undefined)[] = []
+
+  let store = atom<string | undefined>('old')
+
+  let unbind = store.subscribe(value => {
+    events.push(value)
+  })
+  equal(events, ['old'])
+
+  store.set('old')
+  equal(events, ['old'])
+
+  store.set('new')
+  equal(events, ['old', 'new'])
+
+  unbind()
+  clock.runAll()
+})
+
 test.run()

--- a/package.json
+++ b/package.json
@@ -1,5 +1,4 @@
 {
-  "packageManager": "pnpm@8.2.0",
   "name": "nanostores",
   "version": "0.8.0",
   "description": "A tiny (334 bytes) state manager for React/Preact/Vue/Svelte with many atomic tree-shakable stores",

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "packageManager": "pnpm@8.2.0",
   "name": "nanostores",
   "version": "0.8.0",
   "description": "A tiny (334 bytes) state manager for React/Preact/Vue/Svelte with many atomic tree-shakable stores",
@@ -104,14 +105,14 @@
       "import": {
         "./index.js": "{ atom }"
       },
-      "limit": "334 B"
+      "limit": "342 B"
     },
     {
       "name": "All",
       "import": {
         "./index.js": "{ map, computed, action }"
       },
-      "limit": "1050 B"
+      "limit": "1056 B"
     }
   ],
   "clean-publish": {


### PR DESCRIPTION
React useSyncExternalStore triggers rerenders only when value is not referentially equal to previous one.

Here updated atom to not notify subscriptions when new value is same.

This change will let as avoid additional checks in user land and rely more on store.subscribe in non-react logic.