### PR TITLE
Drop notifyId and remove store.notify from public api

### DIFF
--- a/atom/errors.ts
+++ b/atom/errors.ts
@@ -7,19 +7,12 @@ store.listen(value => {
   value.value = 2
 })
 
-store.notify()
-store.notify('value')
-// THROWS '"nonExistentKey"' is not assignable to parameter of type '"value"'
-store.notify('nonExistentKey')
-
 let fnStore = atom<() => void>(() => {
   fnStore.set(() => {})
 })
 
 let fn = fnStore.get()
 fn()
-
-fnStore.notify()
 
 let store2 = atom<string | undefined>()
 store2.set("new")

--- a/atom/index.d.ts
+++ b/atom/index.d.ts
@@ -87,19 +87,10 @@ export interface WritableAtom<Value = any> extends ReadableAtom<Value> {
    * @param newValue New store value.
    */
   set(newValue: Value): void
-
-  /**
-   * Trigger listeners without changing value in the key for performance reasons.
-   *
-   * @param changedKey Key that was changed.
-   *                   If not provided that means the whole value was changed.
-   */
-  notify(changedKey?: AllKeys<Value>): void
 }
 
 export type Atom<Value = any> = ReadableAtom<Value> | WritableAtom<Value>
 
-export declare let notifyId: number
 /**
  * Create store with atomic value. It could be a string or an object, which you
  * will replace completely.

--- a/atom/index.js
+++ b/atom/index.js
@@ -2,8 +2,6 @@ import { clean } from '../clean-stores/index.js'
 
 let listenerQueue = []
 
-export let notifyId = 0
-
 export let atom = (initialValue, level) => {
   let listeners = []
   let store = {
@@ -34,7 +32,6 @@ export let atom = (initialValue, level) => {
       }
 
       if (runListenerQueue) {
-        notifyId++
         for (let i = 0; i < listenerQueue.length; i += 4) {
           let skip = false
           for (let j = i + 7; j < listenerQueue.length; j += 4) {

--- a/computed/index.js
+++ b/computed/index.js
@@ -1,18 +1,13 @@
 import { onMount } from '../lifecycle/index.js'
-import { atom, notifyId } from '../atom/index.js'
+import { atom } from '../atom/index.js'
 
 export let computed = (stores, cb) => {
   if (!Array.isArray(stores)) stores = [stores]
 
-  let diamondNotifyId
   let diamondArgs = []
   let run = () => {
     let args = stores.map(store => store.get())
-    if (
-      diamondNotifyId !== notifyId ||
-      args.some((arg, i) => arg !== diamondArgs[i])
-    ) {
-      diamondNotifyId = notifyId
+    if (args.some((arg, i) => arg !== diamondArgs[i])) {
       diamondArgs = args
       derived.set(cb(...args))
     }

--- a/package.json
+++ b/package.json
@@ -104,14 +104,14 @@
       "import": {
         "./index.js": "{ atom }"
       },
-      "limit": "318 B"
+      "limit": "313 B"
     },
     {
       "name": "All",
       "import": {
         "./index.js": "{ map, computed, action }"
       },
-      "limit": "1037 B"
+      "limit": "1018 B"
     }
   ],
   "clean-publish": {


### PR DESCRIPTION
`store.notify()` was used to enforce update when no value is changed though this case is not valid in react which checks referential equality before update.

Here remove store.notify from types and dropped notifyId which was used to enforce recomputing of dependent computed stores.