### PR TITLE
Fix README typo: .listen() -> .subscribe()

### DIFF
--- a/README.md
+++ b/README.md
@@ -550,7 +550,7 @@ It passes store’s value to callback.
 ```js
 import { profile } from '../stores/profile.js'
 
-profile.listen(() => {
+profile.subscribe(() => {
   console.log(`Hi, ${profile.name}`)
 })
 ```


### PR DESCRIPTION
Simple docs typo fix: The example is supposed to be for `Store#subscribe()`, not `.listen()`.