### PR TITLE
Store atom state in context

### DIFF
--- a/README.md
+++ b/README.md
@@ -550,8 +550,8 @@ It passes store’s value to callback.
 ```js
 import { profile } from '../stores/profile.js'
 
-profile.listen(() => {
-  console.log(`Hi, ${profile.name}`)
+profile.listen(({ name }) => {
+  console.log(`Hi, ${name}`)
 })
 ```
 
@@ -560,7 +560,7 @@ useful for a multiple stores listeners.
 
 ```js
 function render () {
-  console.log(`${post.title} for ${profile.name}`)
+  console.log(`${post.get().title} for ${profile.get().name}`)
 }
 
 profile.listen(render)

--- a/action/index.test.ts
+++ b/action/index.test.ts
@@ -6,7 +6,7 @@ import { lastAction, onNotify, allTasks, action, atom } from '../index.js'
 
 test('shows action name', () => {
   let events: (string | undefined)[] = []
-  let store = atom(1)
+  let store = atom(0)
 
   onNotify(store, () => {
     events.push(store[lastAction])
@@ -45,14 +45,14 @@ test('supports async tasks', async () => {
   equal(await increaseWithDelay(), 'result')
   equal(counter.get(), 2)
 
-  counter.set(2)
+  counter.set(3)
 
   equal(events, ['increaseWithDelay', 'increaseWithDelay', undefined])
 })
 
 test('track previous actionName correctly', () => {
   let events: (string | undefined)[] = []
-  let store = atom(1)
+  let store = atom(0)
 
   onNotify(store, () => {
     events.push(store[lastAction])

--- a/atom/errors.ts
+++ b/atom/errors.ts
@@ -7,19 +7,12 @@ store.listen(value => {
   value.value = 2
 })
 
-store.notify()
-store.notify('value')
-// THROWS '"nonExistentKey"' is not assignable to parameter of type '"value"'
-store.notify('nonExistentKey')
-
 let fnStore = atom<() => void>(() => {
   fnStore.set(() => {})
 })
 
 let fn = fnStore.get()
 fn()
-
-fnStore.notify()
 
 let store2 = atom<string | undefined>()
 store2.set("new")

--- a/atom/index.d.ts
+++ b/atom/index.d.ts
@@ -87,19 +87,10 @@ export interface WritableAtom<Value = any> extends ReadableAtom<Value> {
    * @param newValue New store value.
    */
   set(newValue: Value): void
-
-  /**
-   * Trigger listeners without changing value in the key for performance reasons.
-   *
-   * @param changedKey Key that was changed.
-   *                   If not provided that means the whole value was changed.
-   */
-  notify(changedKey?: AllKeys<Value>): void
 }
 
 export type Atom<Value = any> = ReadableAtom<Value> | WritableAtom<Value>
 
-export declare let notifyId: number
 /**
  * Create store with atomic value. It could be a string or an object, which you
  * will replace completely.

--- a/atom/index.js
+++ b/atom/index.js
@@ -2,8 +2,6 @@ import { clean } from '../clean-stores/index.js'
 
 let listenerQueue = []
 
-export let notifyId = 0
-
 export let atom = (initialValue, level) => {
   let listeners = []
   let store = {
@@ -34,7 +32,6 @@ export let atom = (initialValue, level) => {
       }
 
       if (runListenerQueue) {
-        notifyId++
         for (let i = 0; i < listenerQueue.length; i += 4) {
           let skip = false
           for (let j = i + 7; j < listenerQueue.length; j += 4) {

--- a/atom/index.js
+++ b/atom/index.js
@@ -12,8 +12,10 @@ export let atom = (initialValue, level) => {
     l: level || 0,
     value: initialValue,
     set(data) {
-      store.value = data
-      store.notify()
+      if (store.value !== data) {
+        store.value = data
+        store.notify()
+      }
     },
     get() {
       if (!store.lc) {

--- a/atom/index.js
+++ b/atom/index.js
@@ -1,33 +1,38 @@
 import { clean } from '../clean-stores/index.js'
-
-let listenerQueue = []
+import { getListenerQueue, getStoreState } from '../context/index.js'
 
 export let atom = (initialValue, level) => {
-  let listeners = []
   let store = {
-    lc: 0,
     l: level || 0,
-    value: initialValue,
+    iv: initialValue,
+    get lc() {
+      let state = getStoreState(store)
+      return state.lc
+    },
     set(data) {
-      if (store.value !== data) {
-        store.value = data
+      let state = getStoreState(store)
+      if (state.v !== data) {
+        state.v = data
         store.notify()
       }
     },
     get() {
-      if (!store.lc) {
-        store.listen(() => {})()
+      let state = getStoreState(store)
+      if (!state.lc) {
+        store.listen(() => { })()
       }
-      return store.value
+      return state.v
     },
     notify(changedKey) {
+      let state = getStoreState(store)
+      let listenerQueue = getListenerQueue()
       let runListenerQueue = !listenerQueue.length
-      for (let i = 0; i < listeners.length; i += 2) {
+      for (let i = 0; i < state.ls.length; i += 2) {
         listenerQueue.push(
-          listeners[i],
-          store.value,
+          state.ls[i],
+          state.v,
           changedKey,
-          listeners[i + 1]
+          state.ls[i + 1]
         )
       }
 
@@ -56,30 +61,33 @@ export let atom = (initialValue, level) => {
       }
     },
     listen(listener, listenerLevel) {
-      store.lc = listeners.push(listener, listenerLevel || store.l) / 2
+      let state = getStoreState(store)
+      state.lc = state.ls.push(listener, listenerLevel || store.l) / 2
 
       return () => {
-        let index = listeners.indexOf(listener)
+        let index = state.ls.indexOf(listener)
         if (~index) {
-          listeners.splice(index, 2)
-          store.lc--
-          if (!store.lc) store.off()
+          state.ls.splice(index, 2)
+          state.lc--
+          if (!state.lc) store.off()
         }
       }
     },
     subscribe(cb, listenerLevel) {
+      let state = getStoreState(store)
       let unbind = store.listen(cb, listenerLevel)
-      cb(store.value)
+      cb(state.v)
       return unbind
     },
-    off() {} /* It will be called on last listener unsubscribing.
+    off() { } /* It will be called on last listener unsubscribing.
                 We will redefine it in onMount and onStop. */
   }
 
   if (process.env.NODE_ENV !== 'production') {
     store[clean] = () => {
-      listeners = []
-      store.lc = 0
+      let state = getStoreState(store)
+      state.ls = []
+      state.lc = 0
       store.off()
     }
   }

--- a/atom/index.js
+++ b/atom/index.js
@@ -5,8 +5,7 @@ let listenerQueue = []
 export let notifyId = 0
 
 export let atom = (initialValue, level) => {
-  let currentListeners
-  let nextListeners = []
+  let listeners = []
   let store = {
     lc: 0,
     l: level || 0,
@@ -24,14 +23,13 @@ export let atom = (initialValue, level) => {
       return store.value
     },
     notify(changedKey) {
-      currentListeners = nextListeners
       let runListenerQueue = !listenerQueue.length
-      for (let i = 0; i < currentListeners.length; i += 2) {
+      for (let i = 0; i < listeners.length; i += 2) {
         listenerQueue.push(
-          currentListeners[i],
+          listeners[i],
           store.value,
           changedKey,
-          currentListeners[i + 1]
+          listeners[i + 1]
         )
       }
 
@@ -61,19 +59,12 @@ export let atom = (initialValue, level) => {
       }
     },
     listen(listener, listenerLevel) {
-      if (nextListeners === currentListeners) {
-        nextListeners = nextListeners.slice()
-      }
-
-      store.lc = nextListeners.push(listener, listenerLevel || store.l) / 2
+      store.lc = listeners.push(listener, listenerLevel || store.l) / 2
 
       return () => {
-        if (nextListeners === currentListeners) {
-          nextListeners = nextListeners.slice()
-        }
-        let index = nextListeners.indexOf(listener)
+        let index = listeners.indexOf(listener)
         if (~index) {
-          nextListeners.splice(index, 2)
+          listeners.splice(index, 2)
           store.lc--
           if (!store.lc) store.off()
         }
@@ -90,7 +81,7 @@ export let atom = (initialValue, level) => {
 
   if (process.env.NODE_ENV !== 'production') {
     store[clean] = () => {
-      nextListeners = []
+      listeners = []
       store.lc = 0
       store.off()
     }

--- a/atom/index.test.ts
+++ b/atom/index.test.ts
@@ -295,4 +295,24 @@ test('does not mutate listeners while change event', () => {
   equal(events, ['a1', 'b1', 'a2', 'c2'])
 })
 
+test('prevents notifying when new value is referentially equal to old one', () => {
+  let events: (string | undefined)[] = []
+
+  let store = atom<string | undefined>('old')
+
+  let unbind = store.subscribe(value => {
+    events.push(value)
+  })
+  equal(events, ['old'])
+
+  store.set('old')
+  equal(events, ['old'])
+
+  store.set('new')
+  equal(events, ['old', 'new'])
+
+  unbind()
+  clock.runAll()
+})
+
 test.run()

--- a/computed/index.js
+++ b/computed/index.js
@@ -1,18 +1,13 @@
 import { onMount } from '../lifecycle/index.js'
-import { atom, notifyId } from '../atom/index.js'
+import { atom } from '../atom/index.js'
 
 export let computed = (stores, cb) => {
   if (!Array.isArray(stores)) stores = [stores]
 
-  let diamondNotifyId
   let diamondArgs = []
   let run = () => {
     let args = stores.map(store => store.get())
-    if (
-      diamondNotifyId !== notifyId ||
-      args.some((arg, i) => arg !== diamondArgs[i])
-    ) {
-      diamondNotifyId = notifyId
+    if (args.some((arg, i) => arg !== diamondArgs[i])) {
       diamondArgs = args
       derived.set(cb(...args))
     }

--- a/context/index.js
+++ b/context/index.js
@@ -1,0 +1,32 @@
+let createContext = () => {
+  let context = {
+    // listener queue
+    q: [],
+    // store states
+    s: new Map(),
+  }
+  return context;
+}
+
+let context = createContext()
+
+export let getListenerQueue = () => {
+  return context.q
+}
+
+// lazily initialize store state in context
+export let getStoreState = (store) => {
+  let state = context.s.get(store)
+  if (!state) {
+    state = {
+      // listeners
+      ls: [],
+      // listeners count
+      lc: 0,
+      // value
+      v: store.iv,
+    }
+    context.s.set(store, state)
+  }
+  return state
+}

--- a/deep-map/index.js
+++ b/deep-map/index.js
@@ -1,4 +1,5 @@
 import { atom } from '../atom/index.js'
+import { getStoreState } from '../context/index.js'
 import { getPath, setPath } from './path.js'
 
 export { getPath, setPath } from './path.js'
@@ -6,8 +7,9 @@ export { getPath, setPath } from './path.js'
 export function deepMap(initial = {}) {
   let store = atom(initial)
   store.setKey = (key, value) => {
-    if (getPath(store.value, key) !== value) {
-      store.value = setPath(store.value, key, value)
+    let state = getStoreState(store)
+    if (getPath(state.v, key) !== value) {
+      state.v = setPath(state.v, key, value)
       store.notify(key)
     }
   }

--- a/map/index.js
+++ b/map/index.js
@@ -1,18 +1,20 @@
 import { atom } from '../atom/index.js'
+import { getStoreState } from '../context/index.js'
 
 export let map = (value = {}) => {
   let store = atom(value)
 
   store.setKey = function (key, newValue) {
+    let state = getStoreState(store)
     if (typeof newValue === 'undefined') {
-      if (key in store.value) {
-        store.value = { ...store.value }
-        delete store.value[key]
+      if (key in state.v) {
+        state.v = { ...state.v }
+        delete state.v[key]
         store.notify(key)
       }
-    } else if (store.value[key] !== newValue) {
-      store.value = {
-        ...store.value,
+    } else if (state.v[key] !== newValue) {
+      state.v = {
+        ...state.v,
         [key]: newValue
       }
       store.notify(key)

--- a/package.json
+++ b/package.json
@@ -104,14 +104,14 @@
       "import": {
         "./index.js": "{ atom }"
       },
-      "limit": "313 B"
+      "limit": "403 B"
     },
     {
       "name": "All",
       "import": {
         "./index.js": "{ map, computed, action }"
       },
-      "limit": "1018 B"
+      "limit": "1122 B"
     }
   ],
   "clean-publish": {

--- a/package.json
+++ b/package.json
@@ -104,14 +104,14 @@
       "import": {
         "./index.js": "{ atom }"
       },
-      "limit": "334 B"
+      "limit": "342 B"
     },
     {
       "name": "All",
       "import": {
         "./index.js": "{ map, computed, action }"
       },
-      "limit": "1050 B"
+      "limit": "1056 B"
     }
   ],
   "clean-publish": {

--- a/package.json
+++ b/package.json
@@ -104,14 +104,14 @@
       "import": {
         "./index.js": "{ atom }"
       },
-      "limit": "342 B"
+      "limit": "318 B"
     },
     {
       "name": "All",
       "import": {
         "./index.js": "{ map, computed, action }"
       },
-      "limit": "1056 B"
+      "limit": "1037 B"
     }
   ],
   "clean-publish": {

--- a/package.json
+++ b/package.json
@@ -104,14 +104,14 @@
       "import": {
         "./index.js": "{ atom }"
       },
-      "limit": "318 B"
+      "limit": "313 B"
     },
     {
       "name": "All",
       "import": {
         "./index.js": "{ map, computed, action }"
       },
-      "limit": "1037 B"
+      "limit": "1018 B"
     }
   ],
   "clean-publish": {


### PR DESCRIPTION
Ref https://github.com/nanostores/nanostores/issues/171

Here's initial attempt to move all stores state into global context object. Context is basically a listeners queue and a map of stores states.

Context management api is still yet to explore. For now it's for internal usage now.
The important thing here is accessing context with getter function which can allow to use AsyncLocalStorage in node and cloudflare workers.