### PR TITLE
Store atom state in context

### DIFF
--- a/atom/index.js
+++ b/atom/index.js
@@ -1,34 +1,38 @@
 import { clean } from '../clean-stores/index.js'
-
-let listenerQueue = []
+import { getListenerQueue, getStoreState } from '../context/index.js'
 
 export let atom = (initialValue, level) => {
-  let listeners = []
   let store = {
-    lc: 0,
     l: level || 0,
-    value: initialValue,
+    iv: initialValue,
+    get lc() {
+      let state = getStoreState(store)
+      return state.lc
+    },
+    get value() {
+      let state = getStoreState(store)
+      return state.v
+    },
     set(data) {
-      if (store.value !== data) {
-        store.value = data
+      let state = getStoreState(store)
+      if (state.v !== data) {
+        state.v = data
         store.notify()
       }
     },
     get() {
-      if (!store.lc) {
+      let state = getStoreState(store)
+      if (!state.lc) {
         store.listen(() => {})()
       }
-      return store.value
+      return state.v
     },
     notify(changedKey) {
+      let state = getStoreState(store)
+      let listenerQueue = getListenerQueue()
       let runListenerQueue = !listenerQueue.length
-      for (let i = 0; i < listeners.length; i += 2) {
-        listenerQueue.push(
-          listeners[i],
-          store.value,
-          changedKey,
-          listeners[i + 1]
-        )
+      for (let i = 0; i < state.ls.length; i += 2) {
+        listenerQueue.push(state.ls[i], state.v, changedKey, state.ls[i + 1])
       }
 
       if (runListenerQueue) {
@@ -56,20 +60,22 @@ export let atom = (initialValue, level) => {
       }
     },
     listen(listener, listenerLevel) {
-      store.lc = listeners.push(listener, listenerLevel || store.l) / 2
+      let state = getStoreState(store)
+      state.lc = state.ls.push(listener, listenerLevel || store.l) / 2
 
       return () => {
-        let index = listeners.indexOf(listener)
+        let index = state.ls.indexOf(listener)
         if (~index) {
-          listeners.splice(index, 2)
-          store.lc--
-          if (!store.lc) store.off()
+          state.ls.splice(index, 2)
+          state.lc--
+          if (!state.lc) store.off()
         }
       }
     },
     subscribe(cb, listenerLevel) {
+      let state = getStoreState(store)
       let unbind = store.listen(cb, listenerLevel)
-      cb(store.value)
+      cb(state.v)
       return unbind
     },
     off() {} /* It will be called on last listener unsubscribing.
@@ -78,8 +84,9 @@ export let atom = (initialValue, level) => {
 
   if (process.env.NODE_ENV !== 'production') {
     store[clean] = () => {
-      listeners = []
-      store.lc = 0
+      let state = getStoreState(store)
+      state.ls = []
+      state.lc = 0
       store.off()
     }
   }

--- a/context/index.js
+++ b/context/index.js
@@ -1,0 +1,32 @@
+let createContext = () => {
+  let context = {
+    // listener queue
+    q: [],
+    // store states
+    s: new Map(),
+  }
+  return context;
+}
+
+let context = createContext()
+
+export let getListenerQueue = () => {
+  return context.q
+}
+
+// lazily initialize store state in context
+export let getStoreState = (store) => {
+  let state = context.s.get(store)
+  if (!state) {
+    state = {
+      // listeners
+      ls: [],
+      // listeners count
+      lc: 0,
+      // value
+      v: store.iv,
+    }
+    context.s.set(store, state)
+  }
+  return state
+}

--- a/deep-map/index.js
+++ b/deep-map/index.js
@@ -1,4 +1,5 @@
 import { atom } from '../atom/index.js'
+import { getStoreState } from '../context/index.js'
 import { getPath, setPath } from './path.js'
 
 export { getPath, setPath } from './path.js'
@@ -6,8 +7,9 @@ export { getPath, setPath } from './path.js'
 export function deepMap(initial = {}) {
   let store = atom(initial)
   store.setKey = (key, value) => {
-    if (getPath(store.value, key) !== value) {
-      store.value = setPath(store.value, key, value)
+    let state = getStoreState(store)
+    if (getPath(state.v, key) !== value) {
+      state.v = setPath(state.v, key, value)
       store.notify(key)
     }
   }

--- a/map/index.js
+++ b/map/index.js
@@ -1,18 +1,20 @@
 import { atom } from '../atom/index.js'
+import { getStoreState } from '../context/index.js'
 
 export let map = (value = {}) => {
   let store = atom(value)
 
   store.setKey = function (key, newValue) {
+    let state = getStoreState(store)
     if (typeof newValue === 'undefined') {
-      if (key in store.value) {
-        store.value = { ...store.value }
-        delete store.value[key]
+      if (key in state.v) {
+        state.v = { ...state.v }
+        delete state.v[key]
         store.notify(key)
       }
-    } else if (store.value[key] !== newValue) {
-      store.value = {
-        ...store.value,
+    } else if (state.v[key] !== newValue) {
+      state.v = {
+        ...state.v,
         [key]: newValue
       }
       store.notify(key)

--- a/package.json
+++ b/package.json
@@ -104,14 +104,14 @@
       "import": {
         "./index.js": "{ atom }"
       },
-      "limit": "313 B"
+      "limit": "411 B"
     },
     {
       "name": "All",
       "import": {
         "./index.js": "{ map, computed, action }"
       },
-      "limit": "1019 B"
+      "limit": "1129 B"
     }
   ],
   "clean-publish": {


### PR DESCRIPTION
Ref https://github.com/nanostores/nanostores/issues/171

Here's initial attempt to move all stores state into global context object. Context is basically a listeners queue and a map of stores states.

Context management api is still yet to explore. For now it's for internal usage now.