### PR TITLE
Fix computed with undefined argument

### DIFF
--- a/computed/index.js
+++ b/computed/index.js
@@ -4,10 +4,13 @@ import { atom } from '../atom/index.js'
 export let computed = (stores, cb) => {
   if (!Array.isArray(stores)) stores = [stores]
 
-  let diamondArgs = []
+  let diamondArgs
   let run = () => {
     let args = stores.map(store => store.get())
-    if (args.some((arg, i) => arg !== diamondArgs[i])) {
+    if (
+      diamondArgs === undefined ||
+      args.some((arg, i) => arg !== diamondArgs[i])
+    ) {
       diamondArgs = args
       derived.set(cb(...args))
     }

--- a/computed/index.test.ts
+++ b/computed/index.test.ts
@@ -346,4 +346,11 @@ test('is compatible with onMount', () => {
   equal(events, 'init destroy ')
 })
 
+test('computes initial value when argument is undefined', () => {
+  let one = atom<string | undefined>(undefined)
+  let two = computed(one, (value: string | undefined) => !!value)
+  equal(one.get(), undefined)
+  equal(two.get(), false)
+})
+
 test.run()

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
       "import": {
         "./index.js": "{ map, computed, action }"
       },
-      "limit": "1019 B"
+      "limit": "1026 B"
     }
   ],
   "clean-publish": {


### PR DESCRIPTION
Ref https://github.com/nanostores/nanostores/issues/201

Notify always forced recomputing before. Now check fails when undefined is compared to out of range index.

Added existance check to diamond args to invalidate initial computation.