### PR TITLE
removing notifyId comparison from computed storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules/
+package-lock.json
+.vscode
 
 coverage/

--- a/atom/index.d.ts
+++ b/atom/index.d.ts
@@ -99,7 +99,6 @@ export interface WritableAtom<Value = any> extends ReadableAtom<Value> {
 
 export type Atom<Value = any> = ReadableAtom<Value> | WritableAtom<Value>
 
-export declare let notifyId: number
 /**
  * Create store with atomic value. It could be a string or an object, which you
  * will replace completely.

--- a/atom/index.js
+++ b/atom/index.js
@@ -2,8 +2,6 @@ import { clean } from '../clean-stores/index.js'
 
 let listenerQueue = []
 
-export let notifyId = 0
-
 export let atom = (initialValue, level) => {
   let currentListeners
   let nextListeners = []
@@ -34,7 +32,6 @@ export let atom = (initialValue, level) => {
       }
 
       if (runListenerQueue) {
-        notifyId++
         for (let i = 0; i < listenerQueue.length; i += 4) {
           let skip = false
           for (let j = i + 7; j < listenerQueue.length; j += 4) {

--- a/computed/index.js
+++ b/computed/index.js
@@ -1,18 +1,13 @@
 import { onMount } from '../lifecycle/index.js'
-import { atom, notifyId } from '../atom/index.js'
+import { atom } from '../atom/index.js'
 
 export let computed = (stores, cb) => {
   if (!Array.isArray(stores)) stores = [stores]
 
-  let diamondNotifyId
   let diamondArgs = []
   let run = () => {
     let args = stores.map(store => store.get())
-    if (
-      diamondNotifyId !== notifyId ||
-      args.some((arg, i) => arg !== diamondArgs[i])
-    ) {
-      diamondNotifyId = notifyId
+    if (args.some((arg, i) => arg !== diamondArgs[i])) {
       diamondArgs = args
       derived.set(cb(...args))
     }

--- a/computed/index.test.ts
+++ b/computed/index.test.ts
@@ -349,4 +349,54 @@ test('is compatible with onMount', () => {
   equal(events, 'init destroy ')
 })
 
+test('store should not be calculated with the same primitive parameter', () => {
+  let store = atom<string>('111')
+
+  let render = 0
+  let combine = computed(store, storeValue => {
+    render += 1
+    return `calc_${storeValue}`
+  })
+  equal(render, 0)
+
+  let value: StoreValue<typeof combine> = ''
+  combine.subscribe(combineValue => (value = combineValue))
+  equal(render, 1)
+
+  store.set('222')
+  equal(value, 'calc_222')
+  equal(render, 2)
+
+  store.set('222')
+  equal(value, 'calc_222')
+  equal(render, 2)
+})
+
+test('store should not be calculated with the same primitive parameter, if other store was changed', () => {
+  let store = atom('111')
+  let otherStore = atom(0)
+
+  let render = 0
+  let combine = computed(store, storeValue => {
+    render += 1
+    return `calc_${storeValue}`
+  })
+  equal(render, 0)
+
+  let value: StoreValue<typeof combine> = ''
+  combine.subscribe(combineValue => (value = combineValue))
+  equal(render, 1)
+
+  store.set('222')
+  equal(value, 'calc_222')
+  equal(render, 2)
+
+  otherStore.set(Math.random())
+  equal(render, 2)
+
+  store.set('222')
+  equal(value, 'calc_222')
+  equal(render, 2)
+})
+
 test.run()


### PR DESCRIPTION
I don't want to do difficult calculations with the same parameters. I think, that changing parameters is the only reason to recalculate computed store