### PR TITLE
types(map): extend `MapCreator`

### DIFF
--- a/map/index.d.ts
+++ b/map/index.d.ts
@@ -131,6 +131,7 @@ export interface MapCreator<
   Args extends any[] = []
 > {
   (id: string, ...args: Args): MapStore<Value>
+  build(id: string, ...args: Args): MapStore<Value>
   cache: {
     [id: string]: MapStore<Value & { id: string }>
   }


### PR DESCRIPTION
These changes are needed to make the `build` method a standard for creating store builders.