### PR TITLE
Local contexts

### DIFF
--- a/atom/index.js
+++ b/atom/index.js
@@ -74,12 +74,12 @@ export let atom = (initialValue, level = 0) => {
       listener(state.v)
       return unbind
     },
-    set value(newVal) {
-      getStoreState(this, $atom).v = newVal
-    },
     get value() {
       let state = getStoreState(this, $atom)
       return state.v
+    },
+    set value(newVal) {
+      getStoreState(this, $atom).v = newVal
     }
   }
 

--- a/context/index.d.ts
+++ b/context/index.d.ts
@@ -11,6 +11,11 @@ export type WithCtx = {
 export declare const globalContext: Context
 
 export function createContext(storeValues?: object): Context
+export function createLocalContext(
+  parentContext: Context,
+  id: string,
+  storeValues?: object
+): Context
 export function resetContext(context?: Context): void
 export function serializeContext(context: Context): string
 

--- a/context/production.test.ts
+++ b/context/production.test.ts
@@ -2,24 +2,53 @@ import { test } from 'uvu'
 import { equal, throws } from 'uvu/assert'
 
 import { atom } from '../atom/index.js'
-import { createContext, resetContext } from './index.js'
+import {
+  createContext,
+  createLocalContext,
+  globalContext,
+  resetContext,
+  withContext
+} from './index.js'
 
-test.before(() => {
+test.before.each(() => {
   process.env.NODE_ENV = 'production'
 })
 
-test.after(() => {
+test.after.each(() => {
   process.env.NODE_ENV = 'test'
   resetContext()
 })
 
-test.only('polluted global context throws an error', () => {
+test('traversing incorrect tree leads to error', () => {
+  let ctx1 = createContext()
+  let $custom = atom(1)
+  withContext($custom, ctx1)
+
+  let localCtx = createLocalContext(globalContext, 'local1')
+  throws(() => withContext($custom, localCtx), /Incorrect atom tree/)
+})
+
+test(`Incorrect atom tree`, () => {
   let $atom = atom(0)
+  let ctx = createContext()
+  let localCtx = createLocalContext(ctx, 'local')
 
-  equal($atom.get(), 0)
-  createContext()
+  withContext($atom, localCtx)
 
-  throws(() => $atom.get(), 'no global ctx')
+  throws(() => withContext($atom, ctx), /Incorrect atom tree/)
+})
+
+test(`Incorrect atom tree #2`, () => {
+  let $global = atom(0)
+
+  let ctx1 = createContext()
+  let localCtx1 = createLocalContext(ctx1, 'local1')
+  let localGlobalCtx1 = createLocalContext(globalContext, 'local-global-1')
+
+  equal($global.get(), 0)
+
+  equal(withContext($global, localGlobalCtx1).get(), 0)
+  throws(() => withContext($global, localCtx1), /Incorrect atom tree/)
 })
 
 test.run()

--- a/index.d.ts
+++ b/index.d.ts
@@ -4,6 +4,7 @@ export { clean, cleanStores } from './clean-stores/index.js'
 export { batched, computed } from './computed/index.js'
 export {
   createContext,
+  createLocalContext,
   globalContext,
   resetContext,
   serializeContext,

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ export { clean, cleanStores } from './clean-stores/index.js'
 export { batched, computed } from './computed/index.js'
 export {
   createContext,
+  createLocalContext,
   globalContext,
   resetContext,
   serializeContext,

--- a/package.json
+++ b/package.json
@@ -108,14 +108,14 @@
       "import": {
         "./index.js": "{ atom }"
       },
-      "limit": "508 B"
+      "limit": "586 B"
     },
     {
       "name": "All",
       "import": {
         "./index.js": "{ map, computed, action }"
       },
-      "limit": "1557 B"
+      "limit": "1649 B"
     }
   ],
   "clean-publish": {


### PR DESCRIPTION
To do:

- [ ] serialize/deserialize nested contexts + tests

The basic problem this PR aims to solve is that we don't have a feasible way to work with local component state. Say, you want to have a form component that can have multiple independent instances at a time. Generic contexts could help you with this, but they create a completely _new_ space, therefore limiting your ability to use atoms from the higher contexts.

This is where Local Contexts come into play. This is a hidden core feature which most users don't need to know about. Instead they will interact with it in the framework space. So, pseudo-code time!

```tsx
/**
 * 2 new exports in all framework-related libs:
 * 1. `NanostoresContext`. Component that handles context switches. More about it later
 * 2. `useCtx`. Returns the `ctx` wrapper that's used for cases like setting an input value
 *
 * For the purposes of gradual adoption both are actually optional: if you don't use
 * `NanostoresContext`, it'll take the default value (global context), same applies to
 * direct `$store.set()` calls.
 *
 * These two are not local context-specific, they are a requirement for contexts in general.
 */
import { useStore, useCtx, NanostoresContext } from "@nanostores/react";
import { atom, computed } from "nanostores";

const App = () => {
  /**
   * In this case we create a "custom" context limited to a request. This can be whatever
   * random memoized value we have.
   * Not sure if we'll go this route, but that'll require a first attempt at making it
   * work with a meta-framework (Next/Nuxt).
   *
   * I have a feeling that we'll need a middleware that would work out the machinery
   * of a meta-framework: create persistent req.id, initial render, `await allTasks`,
   * serialize context, deserialize context on client. So there's a high possibility
   * this all will be hidden from the end developer.
   */
  return (
    <NanostoresContext id="req_id">
      <User />
      <InputWrapper levels={5} />
    </NanostoresContext>
  );
};

/**
 * This is a "custom" atom. First time it's called with a "custom" context, it's marked
 * accordingly. After that you'll never be able to call it directly in module (this will
 * throw an error).
 */
const $user = atom({ username: "dkzlv" });

const User = () => {
  const user = useStore($user);
  return <p>Usename: {user.username}</p>;
};

/**
 * This looks to be a "custom" atom, but it in fact will be used as a local one,
 * because first time you use it (in `useStore`) you'll have a local context.
 */
const $inputValue = atom("");
/**
 * And even though `$inputValue` and `$user` are attached to different contexts,
 * this will work as expected! The resulting `computed` will also be a "local" atom.
 * Its local context has a parent context, which is the "custom" from above, so we
 * traverse the linked list until we find a fitting context.
 */
const $displayValue = computed(
  [$user, $inputValue],
  (user, input) => `${user.username} ++ ${input}`
);

const InputWrapper = ({ levels }: { levels: number }) => {
  return (
    /**
     * We hide the calls to `createLocalContext` and `createContext`, the surface is
     * the id property.
     */
    <NanostoresContext localId={`${levels}_id`}>
      <Input />
      {levels > 0 ? (
        // We can nest local contexts into each other!
        <InputWrapper levels={levels - 1} />
      ) : null}
    </NanostoresContext>
  );
};

const Input = () => {
  const inputValue = useStore($inputValue);
  const display = useStore($displayValue);
  const ctx = useCtx();

  return (
    <div>
      {display}
      <input
        value={inputValue}
        onChange={(e) => ctx($inputValue).set(e.currentTarget.value)}
      />
    </div>
  );
};
```