### PR TITLE
feat!: have oldVal passed on notify

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,6 @@ jobs:
       matrix:
         node-version:
           - 18
-          - 16
     name: Node.js ${{ matrix.node-version }} Quick
     steps:
       - name: Checkout the repository

--- a/README.md
+++ b/README.md
@@ -290,24 +290,23 @@ export const $admins = computed($users, users => {
 })
 ```
 
-By default, `computed` stores update _each_ time any of their dependencies gets updated.
-If you are fine with waiting until the end of a tick, you can use `batched`. The only
-difference with `computed` is that it will wait until the end of a tick to update
-itself.
+By default, `computed` stores update _each_ time any of their dependencies
+gets updated. If you are fine with waiting until the end of a tick, you can
+use `batched`. The only difference with `computed` is that it will wait until
+the end of a tick to update itself.
 
 ```ts
 import { batched } from 'nanostores'
 
 const $sortBy = atom('id')
-const $categoryIdFilter = atom('')
+const $categoryId = atom('')
 
-export const $link = batched([$sortBy, $categoryIdFilter], (sortBy, categoryId) => {
-    return `/api/entities?sortBy=${sortBy}&categoryId=${categoryId}`
-  },
-)
+export const $link = batched([$sortBy, $categoryId], (sortBy, categoryId) => {
+  return `/api/entities?sortBy=${sortBy}&categoryId=${categoryId}`
+})
 
-// `batched` will update only once even though you changed two stores in succession
-export const resetFilters = () => {
+// `batched` will update only once even you changed two stores
+export function resetFilters () {
   $sortBy.set('date')
   $categoryIdFilter.set('1')
 }

--- a/README.md
+++ b/README.md
@@ -296,9 +296,37 @@ You can combine a value from multiple stores:
 import { $lastVisit } from './lastVisit.js'
 import { $posts } from './posts.js'
 
-export const newPosts = computed([$lastVisit, $posts], (lastVisit, posts) => {
+export const $newPosts = computed([$lastVisit, $posts], (lastVisit, posts) => {
   return posts.filter(post => post.publishedAt > lastVisit)
 })
+```
+
+There's also a third optional argument called `batched`. By default, computed stores
+update _each_ time any of their dependencies gets updated. If you are fine with waiting
+until the end of a tick, pass in `true` so your constructor function's only called
+once per tick tops.
+
+```ts
+
+const $sortBy = atom('id')
+const $categoryIdFilter = atom('')
+
+export const $link = computed(
+  [$sortBy, $categoryIdFilter],
+  (sortBy, categoryId) => {
+    return `/api/entities?sortBy=${sortBy}&categoryId=${categoryId}`
+  },
+  // Notice this argument!
+  true
+)
+
+/**
+ * `computed` will only update once even though you updated two stores in succession
+ */
+export const resetFilters = () => {
+  $sortBy.set('date')
+  $categoryIdFilter.set('1')
+}
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -131,6 +131,15 @@ export type LoadingStateValue = 'empty' | 'loading' | 'loaded'
 export const $loadingState = atom<LoadingStateValue>('empty')
 ```
 
+Then you can use `StoreValue<Store>` helper to get store’s value type
+in TypeScript:
+
+```ts
+import type { StoreValue } from 'nanostores'
+
+type Value = StoreValue<typeof $loadingState> //=> LoadingStateValue
+```
+
 `store.get()` will return store’s current value.
 `store.set(nextValue)` will change value.
 

--- a/README.md
+++ b/README.md
@@ -299,6 +299,19 @@ export const $admins = computed($users, users => {
 })
 ```
 
+An async function can be evaluated by using `task()`.
+
+```js
+import { computed, task } from 'nanostores'
+
+import { $userId } from './users.js'
+
+export const $user = computed($userId, userId => task(async () => {
+  const response = await fetch(`https://my-api/users/${userId}`)
+  return response.json()
+}))
+```
+
 By default, `computed` stores update _each_ time any of their dependencies
 gets updated. If you are fine with waiting until the end of a tick, you can
 use `batched`. The only difference with `computed` is that it will wait until

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A tiny state manager for **React**, **React Native**, **Preact**, **Vue**,
 **Svelte**, **Solid**, **Lit**, **Angular**, and vanilla JS.
 It uses **many atomic stores** and direct manipulation.
 
-* **Small.** Between 297 and 1045 bytes (minified and gzipped).
+* **Small.** Between 297 and 1081 bytes (minified and gzipped).
   Zero dependencies. It uses [Size Limit] to control size.
 * **Fast.** With small atomic and derived stores, you do not need to call
   the selector function for all components on every store change.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A tiny state manager for **React**, **React Native**, **Preact**, **Vue**,
 **Svelte**, **Solid**, **Lit**, **Angular**, and vanilla JS.
 It uses **many atomic stores** and direct manipulation.
 
-* **Small.** Between 297 and 1013 bytes (minified and gzipped).
+* **Small.** Between 297 and 1039 bytes (minified and gzipped).
   Zero dependencies. It uses [Size Limit] to control size.
 * **Fast.** With small atomic and derived stores, you do not need to call
   the selector function for all components on every store change.
@@ -320,9 +320,7 @@ export const $link = computed(
   true
 )
 
-/**
- * `computed` will only update once even though you updated two stores in succession
- */
+// `computed` will only update once even though you updated two stores in succession
 export const resetFilters = () => {
   $sortBy.set('date')
   $categoryIdFilter.set('1')

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A tiny state manager for **React**, **React Native**, **Preact**, **Vue**,
 **Svelte**, **Solid**, **Lit**, **Angular**, and vanilla JS.
 It uses **many atomic stores** and direct manipulation.
 
-* **Small.** Between 297 and 1039 bytes (minified and gzipped).
+* **Small.** Between 297 and 1045 bytes (minified and gzipped).
   Zero dependencies. It uses [Size Limit] to control size.
 * **Fast.** With small atomic and derived stores, you do not need to call
   the selector function for all components on every store change.
@@ -290,7 +290,30 @@ export const $admins = computed($users, users => {
 })
 ```
 
-You can combine a value from multiple stores:
+By default, `computed` stores update _each_ time any of their dependencies gets updated.
+If you are fine with waiting until the end of a tick, you can use `batched`. The only
+difference with `computed` is that it will wait until the end of a tick to update
+itself.
+
+```ts
+import { batched } from 'nanostores'
+
+const $sortBy = atom('id')
+const $categoryIdFilter = atom('')
+
+export const $link = batched([$sortBy, $categoryIdFilter], (sortBy, categoryId) => {
+    return `/api/entities?sortBy=${sortBy}&categoryId=${categoryId}`
+  },
+)
+
+// `batched` will update only once even though you changed two stores in succession
+export const resetFilters = () => {
+  $sortBy.set('date')
+  $categoryIdFilter.set('1')
+}
+```
+
+Both `computed` and `batched` can be calculated from multiple stores:
 
 ```ts
 import { $lastVisit } from './lastVisit.js'
@@ -300,33 +323,6 @@ export const $newPosts = computed([$lastVisit, $posts], (lastVisit, posts) => {
   return posts.filter(post => post.publishedAt > lastVisit)
 })
 ```
-
-There's also a third optional argument called `batched`. By default, computed stores
-update _each_ time any of their dependencies gets updated. If you are fine with waiting
-until the end of a tick, pass in `true` so your constructor function's only called
-once per tick tops.
-
-```ts
-
-const $sortBy = atom('id')
-const $categoryIdFilter = atom('')
-
-export const $link = computed(
-  [$sortBy, $categoryIdFilter],
-  (sortBy, categoryId) => {
-    return `/api/entities?sortBy=${sortBy}&categoryId=${categoryId}`
-  },
-  // Notice this argument!
-  true
-)
-
-// `computed` will only update once even though you updated two stores in succession
-export const resetFilters = () => {
-  $sortBy.set('date')
-  $categoryIdFilter.set('1')
-}
-```
-
 
 ### Actions
 

--- a/atom/index.js
+++ b/atom/index.js
@@ -60,7 +60,7 @@ export let atom = (initialValue, level) => {
     off() {} /* It will be called on last listener unsubscribing.
                  We will redefine it in onMount and onStop. */,
     set(newVal) {
-      const oldVal = $atom.value
+      let oldVal = $atom.value
       if (oldVal !== newVal) {
         $atom.value = newVal
         $atom.notify(oldVal)

--- a/atom/index.js
+++ b/atom/index.js
@@ -6,9 +6,7 @@ export let atom = (initialValue, level) => {
   let listeners = []
   let $atom = {
     get() {
-      if (!$atom.lc) {
-        $atom.listen(() => {})()
-      }
+      if (!$atom.lc) $atom.listen(() => {})()
       return $atom.value
     },
     l: level || 0,
@@ -57,8 +55,10 @@ export let atom = (initialValue, level) => {
         listenerQueue.length = 0
       }
     },
-    off() {} /* It will be called on last listener unsubscribing.
-                 We will redefine it in onMount and onStop. */,
+
+    /* It will be called on last listener unsubscribing.We will redefine it in onMount and onStop. */
+    off() {},
+
     set(newVal) {
       let oldVal = $atom.value
       if (oldVal !== newVal) {

--- a/atom/index.js
+++ b/atom/index.js
@@ -56,8 +56,8 @@ export let atom = (initialValue, level) => {
       }
     },
 
-    /* It will be called on last listener unsubscribing.We will redefine it in onMount and onStop. */
-    off() {},
+    off() {}, /* It will be called on last listener unsubscribing.
+                 We will redefine it in onMount and onStop. */
 
     set(newVal) {
       let oldVal = $atom.value

--- a/atom/index.js
+++ b/atom/index.js
@@ -24,28 +24,29 @@ export let atom = (initialValue, level) => {
         }
       }
     },
-    notify(changedKey) {
+    notify(oldVal, changedKey) {
       let runListenerQueue = !listenerQueue.length
       for (let i = 0; i < listeners.length; i += 2) {
         listenerQueue.push(
           listeners[i],
           listeners[i + 1],
           $atom.value,
-          changedKey,
+          oldVal,
+          changedKey
         )
       }
 
       if (runListenerQueue) {
         for (let i = 0; i < listenerQueue.length; i += 4) {
           let skip
-          for (let j = i + 1; !skip && (j += 4) < listenerQueue.length;) {
+          for (let j = i + 1; !skip && (j += 4) < listenerQueue.length; ) {
             if (listenerQueue[j] < listenerQueue[i + 1]) {
               skip = listenerQueue.push(
-               listenerQueue[i],
-               listenerQueue[i + 1],
-               listenerQueue[i + 2],
-               listenerQueue[i + 3]
-             )
+                listenerQueue[i],
+                listenerQueue[i + 1],
+                listenerQueue[i + 2],
+                listenerQueue[i + 3]
+              )
             }
           }
 
@@ -56,12 +57,13 @@ export let atom = (initialValue, level) => {
         listenerQueue.length = 0
       }
     },
-    off() {}, /* It will be called on last listener unsubscribing.
-                 We will redefine it in onMount and onStop. */
-    set(data) {
-      if ($atom.value !== data) {
-        $atom.value = data
-        $atom.notify()
+    off() {} /* It will be called on last listener unsubscribing.
+                 We will redefine it in onMount and onStop. */,
+    set(newVal) {
+      const oldVal = $atom.value
+      if (oldVal !== newVal) {
+        $atom.value = newVal
+        $atom.notify(oldVal)
       }
     },
     subscribe(listener, listenerLevel) {
@@ -69,7 +71,7 @@ export let atom = (initialValue, level) => {
       listener($atom.value)
       return unbind
     },
-    value: initialValue
+    value: initialValue,
   }
 
   if (process.env.NODE_ENV !== 'production') {

--- a/atom/index.js
+++ b/atom/index.js
@@ -71,7 +71,7 @@ export let atom = (initialValue, level) => {
       listener($atom.value)
       return unbind
     },
-    value: initialValue,
+    value: initialValue
   }
 
   if (process.env.NODE_ENV !== 'production') {

--- a/clean-stores/index.d.ts
+++ b/clean-stores/index.d.ts
@@ -1,4 +1,5 @@
-import type { MapCreator, Store } from '../map/index.js'
+import type { MapCreator } from '../map-creator/index.js'
+import type { Store } from '../map/index.js'
 
 export const clean: unique symbol
 
@@ -18,4 +19,6 @@ export const clean: unique symbol
  * @param stores Used store classes.
  * @return Promise for stores destroying.
  */
-export function cleanStores(...stores: (MapCreator | Store | undefined)[]): void
+export function cleanStores(
+  ...stores: (MapCreator<any, any[]> | Store | undefined)[]
+): void

--- a/computed/index.d.ts
+++ b/computed/index.d.ts
@@ -19,11 +19,10 @@ interface Computed {
    * Create derived store, which use generates value from another stores.
    *
    * ```js
-   * import { computed, batched } from 'nanostores'
+   * import { computed } from 'nanostores'
    *
    * import { $users } from './users.js'
    *
-   * // or `batched($users, …)`
    * export const $admins = computed($users, users => {
    *   return users.filter(user => user.isAdmin)
    * })
@@ -36,4 +35,30 @@ interface Computed {
 }
 
 export const computed: Computed
-export const batched: Computed
+
+interface Batched {
+  <Value extends any, OriginStore extends Store>(
+    stores: OriginStore,
+    cb: (value: StoreValue<OriginStore>) => Value
+  ): ReadableAtom<Value>
+  /**
+   * Create derived store, which use generates value from another stores.
+   *
+   * ```js
+   * import { batched } from 'nanostores'
+   *
+   * const $sortBy = atom('id')
+   * const $category = atom('')
+   *
+   * export const $link = batched([$sortBy, $category], (sortBy, category) => {
+   *   return `/api/entities?sortBy=${sortBy}&category=${category}`
+   * })
+   * ```
+   */
+  <Value extends any, OriginStores extends AnyStore[]>(
+    stores: [...OriginStores],
+    cb: (...values: StoreValues<OriginStores>) => Value
+  ): ReadableAtom<Value>
+}
+
+export const batched: Batched

--- a/computed/index.d.ts
+++ b/computed/index.d.ts
@@ -14,15 +14,7 @@ type C = (...values: StoreValues<[A, B]>) => void
 interface Computed {
   <Value extends any, OriginStore extends Store>(
     stores: OriginStore,
-    cb: (value: StoreValue<OriginStore>) => Task<Value>
-  ): ReadableAtom<Value>
-  <Value extends any, OriginStores extends AnyStore[]>(
-    stores: [...OriginStores],
-    cb: (...values: StoreValues<OriginStores>) => Task<Value>
-  ): ReadableAtom<Value>
-  <Value extends any, OriginStore extends Store>(
-    stores: OriginStore,
-    cb: (value: StoreValue<OriginStore>) => Value
+    cb: (value: StoreValue<OriginStore>) => Task<Value> | Value
   ): ReadableAtom<Value>
   /**
    * Create derived store, which use generates value from another stores.

--- a/computed/index.d.ts
+++ b/computed/index.d.ts
@@ -1,5 +1,6 @@
 import type { ReadableAtom } from '../atom/index.js'
 import type { AnyStore, Store, StoreValue } from '../map/index.js'
+import type { Task } from '../task/index.js'
 
 type StoreValues<Stores extends AnyStore[]> = {
   [Index in keyof Stores]: StoreValue<Stores[Index]>
@@ -11,6 +12,14 @@ type B = ReadableAtom<string>
 type C = (...values: StoreValues<[A, B]>) => void
 
 interface Computed {
+  <Value extends any, OriginStore extends Store>(
+    stores: OriginStore,
+    cb: (value: StoreValue<OriginStore>) => Task<Value>
+  ): ReadableAtom<Value>
+  <Value extends any, OriginStores extends AnyStore[]>(
+    stores: [...OriginStores],
+    cb: (...values: StoreValues<OriginStores>) => Task<Value>
+  ): ReadableAtom<Value>
   <Value extends any, OriginStore extends Store>(
     stores: OriginStore,
     cb: (value: StoreValue<OriginStore>) => Value
@@ -43,7 +52,7 @@ interface Computed {
    */
   <Value extends any, OriginStores extends AnyStore[]>(
     stores: [...OriginStores],
-    cb: (...values: StoreValues<OriginStores>) => Value
+    cb: (...values: StoreValues<OriginStores>) => Task<Value> | Value
   ): ReadableAtom<Value>
 }
 

--- a/computed/index.d.ts
+++ b/computed/index.d.ts
@@ -13,7 +13,8 @@ type C = (...values: StoreValues<[A, B]>) => void
 interface Computed {
   <Value extends any, OriginStore extends Store>(
     stores: OriginStore,
-    cb: (value: StoreValue<OriginStore>) => Value
+    cb: (value: StoreValue<OriginStore>) => Value,
+    batched?: boolean
   ): ReadableAtom<Value>
   /**
    * Create derived store, which use generates value from another stores.
@@ -30,7 +31,8 @@ interface Computed {
    */
   <Value extends any, OriginStores extends AnyStore[]>(
     stores: [...OriginStores],
-    cb: (...values: StoreValues<OriginStores>) => Value
+    cb: (...values: StoreValues<OriginStores>) => Value,
+    batched?: boolean
   ): ReadableAtom<Value>
 }
 

--- a/computed/index.d.ts
+++ b/computed/index.d.ts
@@ -13,17 +13,17 @@ type C = (...values: StoreValues<[A, B]>) => void
 interface Computed {
   <Value extends any, OriginStore extends Store>(
     stores: OriginStore,
-    cb: (value: StoreValue<OriginStore>) => Value,
-    batched?: boolean
+    cb: (value: StoreValue<OriginStore>) => Value
   ): ReadableAtom<Value>
   /**
    * Create derived store, which use generates value from another stores.
    *
    * ```js
-   * import { computed } from 'nanostores'
+   * import { computed, batched } from 'nanostores'
    *
    * import { $users } from './users.js'
    *
+   * // or `batched($users, …)`
    * export const $admins = computed($users, users => {
    *   return users.filter(user => user.isAdmin)
    * })
@@ -31,9 +31,9 @@ interface Computed {
    */
   <Value extends any, OriginStores extends AnyStore[]>(
     stores: [...OriginStores],
-    cb: (...values: StoreValues<OriginStores>) => Value,
-    batched?: boolean
+    cb: (...values: StoreValues<OriginStores>) => Value
   ): ReadableAtom<Value>
 }
 
 export const computed: Computed
+export const batched: Computed

--- a/computed/index.d.ts
+++ b/computed/index.d.ts
@@ -27,6 +27,19 @@ interface Computed {
    *   return users.filter(user => user.isAdmin)
    * })
    * ```
+   *
+   * An async function can be evaluated by using {@link task}.
+   *
+   * ```js
+   * import { computed, task } from 'nanostores'
+   *
+   * import { $userId } from './users.js'
+   *
+   * export const $user = computed($userId, userId => task(async () => {
+   *   const response = await fetch(`https://my-api/users/${userId}`)
+   *   return response.json()
+   * }))
+   * ```
    */
   <Value extends any, OriginStores extends AnyStore[]>(
     stores: [...OriginStores],

--- a/computed/index.js
+++ b/computed/index.js
@@ -1,7 +1,7 @@
 import { atom } from '../atom/index.js'
 import { onMount } from '../lifecycle/index.js'
 
-export let computed = (stores, cb, batched) => {
+let computedStore = (stores, cb, batched) => {
   if (!Array.isArray(stores)) stores = [stores]
 
   let diamondArgs
@@ -36,3 +36,6 @@ export let computed = (stores, cb, batched) => {
 
   return $computed
 }
+
+export let computed = (stores, fn) => computedStore(stores, fn)
+export let batched = (stores, fn) => computedStore(stores, fn, true)

--- a/computed/index.test.ts
+++ b/computed/index.test.ts
@@ -4,8 +4,8 @@ import { equal, ok } from 'uvu/assert'
 
 import {
   atom,
-  computed,
   batched,
+  computed,
   onMount,
   STORE_UNMOUNT_DELAY,
   type StoreValue

--- a/computed/index.test.ts
+++ b/computed/index.test.ts
@@ -5,6 +5,7 @@ import { equal, ok } from 'uvu/assert'
 import {
   atom,
   computed,
+  batched,
   onMount,
   STORE_UNMOUNT_DELAY,
   type StoreValue
@@ -360,7 +361,7 @@ test('batches updates when passing batch arg', () => {
   let st1 = atom('1')
   let st2 = atom('1')
 
-  let cmp = computed([st1, st2], (v1, v2) => v1 + v2, true)
+  let cmp = batched([st1, st2], (v1, v2) => v1 + v2)
 
   let events: string = ''
   cmp.subscribe(v => (events += v))
@@ -381,7 +382,7 @@ test('computes initial value for batch arg without waiting', () => {
   let st1 = atom('1')
   let st2 = atom('1')
 
-  let cmp = computed([st1, st2], (v1, v2) => v1 + v2, true)
+  let cmp = batched([st1, st2], (v1, v2) => v1 + v2)
 
   equal('11', cmp.get())
 })

--- a/computed/index.test.ts
+++ b/computed/index.test.ts
@@ -356,4 +356,34 @@ test('computes initial value when argument is undefined', () => {
   equal($two.get(), false)
 })
 
+test('batches updates when passing batch arg', () => {
+  let st1 = atom('1')
+  let st2 = atom('1')
+
+  let cmp = computed([st1, st2], (v1, v2) => v1 + v2, true)
+
+  let events: string = ''
+  cmp.subscribe(v => (events += v))
+
+  st1.set('2')
+  st2.set('2')
+
+  clock.runAll()
+
+  st1.set('3')
+  st2.set('3')
+
+  clock.runAll()
+  equal('112233', events)
+})
+
+test('computes initial value for batch arg without waiting', () => {
+  let st1 = atom('1')
+  let st2 = atom('1')
+
+  let cmp = computed([st1, st2], (v1, v2) => v1 + v2, true)
+
+  equal('11', cmp.get())
+})
+
 test.run()

--- a/computed/index.test.ts
+++ b/computed/index.test.ts
@@ -8,7 +8,8 @@ import {
   computed,
   onMount,
   STORE_UNMOUNT_DELAY,
-  type StoreValue
+  type StoreValue,
+  task
 } from '../index.js'
 
 let clock: InstalledClock
@@ -378,13 +379,46 @@ test('batches updates when passing batch arg', () => {
   equal('112233', events)
 })
 
-test('computes initial value for batch arg without waiting', () => {
+test('computes initial value for batch arg without waiting', () =>{
   let st1 = atom('1')
   let st2 = atom('1')
-
-  let cmp = batched([st1, st2], (v1, v2) => v1 + v2)
-
+  let cmp = batched([st1, st2], (v1, v2)=>v1 + v2)
   equal('11', cmp.get())
+})
+
+test('async computed using task', async () => {
+  let $a = atom(1)
+  let $b = atom(2)
+  let sleepCycles = 5
+  let taskArgumentsCalls: number[][] = []
+  let $sum = computed([$a, $b],
+    (a, b) =>
+      task(async () => {
+        taskArgumentsCalls.push([a, b])
+        for (let i = 0; i < sleepCycles; i++) {
+          await Promise.resolve()
+        }
+        return a + b
+      }))
+  equal($sum.get(), undefined)
+  equal(taskArgumentsCalls, [[1, 2]])
+
+  sleepCycles = 0
+  $a.set(10)
+  $b.set(20)
+
+  // Nothing happens for 3 event loops
+  for (let i = 0; i < 3; i++) {
+    await Promise.resolve()
+    equal($sum.get(), undefined)
+    equal(taskArgumentsCalls, [[1, 2], [10, 2], [10, 20]])
+  }
+
+  // After the 5th event loop, the $computed.value is set
+  await Promise.resolve()
+  // Stale values are not set
+  equal($sum.get(), 30)
+  equal(taskArgumentsCalls, [[1, 2], [10, 2], [10, 20]])
 })
 
 test.run()

--- a/deep-map/index.js
+++ b/deep-map/index.js
@@ -6,7 +6,7 @@ export { getPath, setPath } from './path.js'
 export function deepMap(initial = {}) {
   let $deepMap = atom(initial)
   $deepMap.setKey = (key, newVal) => {
-    const oldVal = getPath($deepMap.value, key)
+    let oldVal = getPath($deepMap.value, key)
     if (oldVal !== newVal) {
       $deepMap.value = setPath($deepMap.value, key, newVal)
       $deepMap.notify(oldVal, key)

--- a/deep-map/index.js
+++ b/deep-map/index.js
@@ -5,10 +5,11 @@ export { getPath, setPath } from './path.js'
 
 export function deepMap(initial = {}) {
   let $deepMap = atom(initial)
-  $deepMap.setKey = (key, value) => {
-    if (getPath($deepMap.value, key) !== value) {
-      $deepMap.value = setPath($deepMap.value, key, value)
-      $deepMap.notify(key)
+  $deepMap.setKey = (key, newVal) => {
+    const oldVal = getPath($deepMap.value, key)
+    if (oldVal !== newVal) {
+      $deepMap.value = setPath($deepMap.value, key, newVal)
+      $deepMap.notify(oldVal, key)
     }
   }
   return $deepMap

--- a/deep-map/index.js
+++ b/deep-map/index.js
@@ -5,11 +5,11 @@ export { getPath, setPath } from './path.js'
 
 export function deepMap(initial = {}) {
   let $deepMap = atom(initial)
-  $deepMap.setKey = (key, newVal) => {
-    let oldVal = getPath($deepMap.value, key)
-    if (oldVal !== newVal) {
-      $deepMap.value = setPath($deepMap.value, key, newVal)
-      $deepMap.notify(oldVal, key)
+  $deepMap.setKey = (key, newValue) => {
+    let oldValue = getPath($deepMap.value, key)
+    if (oldValue !== newValue) {
+      $deepMap.value = setPath($deepMap.value, key, newValue)
+      $deepMap.notify(oldValue, key)
     }
   }
   return $deepMap

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,7 @@
 export { action, actionId, lastAction } from './action/index.js'
 export { atom, Atom, ReadableAtom, WritableAtom } from './atom/index.js'
 export { clean, cleanStores } from './clean-stores/index.js'
-export { computed } from './computed/index.js'
+export { computed, batched } from './computed/index.js'
 export {
   AllPaths,
   BaseDeepMap,

--- a/index.d.ts
+++ b/index.d.ts
@@ -22,10 +22,10 @@ export {
   STORE_UNMOUNT_DELAY
 } from './lifecycle/index.js'
 export { listenKeys } from './listen-keys/index.js'
+export { mapCreator, MapCreator } from './map-creator/index.js'
 export {
   AnyStore,
   map,
-  MapCreator,
   MapStore,
   MapStoreKeys,
   Store,

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,7 @@
 export { action, actionId, lastAction } from './action/index.js'
 export { atom, Atom, ReadableAtom, WritableAtom } from './atom/index.js'
 export { clean, cleanStores } from './clean-stores/index.js'
-export { computed, batched } from './computed/index.js'
+export { batched, computed } from './computed/index.js'
 export {
   AllPaths,
   BaseDeepMap,

--- a/index.d.ts
+++ b/index.d.ts
@@ -32,4 +32,4 @@ export {
   StoreValue,
   WritableStore
 } from './map/index.js'
-export { allTasks, cleanTasks, startTask, task } from './task/index.js'
+export { allTasks, cleanTasks, startTask, task, Task } from './task/index.js'

--- a/index.js
+++ b/index.js
@@ -14,5 +14,6 @@ export {
   STORE_UNMOUNT_DELAY
 } from './lifecycle/index.js'
 export { listenKeys } from './listen-keys/index.js'
+export { mapCreator } from './map-creator/index.js'
 export { map } from './map/index.js'
 export { allTasks, cleanTasks, startTask, task } from './task/index.js'

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 export { action, actionId, lastAction } from './action/index.js'
 export { atom } from './atom/index.js'
 export { clean, cleanStores } from './clean-stores/index.js'
-export { computed } from './computed/index.js'
+export { computed, batched } from './computed/index.js'
 export { deepMap, getPath, setPath } from './deep-map/index.js'
 export { keepMount } from './keep-mount/index.js'
 export {

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 export { action, actionId, lastAction } from './action/index.js'
 export { atom } from './atom/index.js'
 export { clean, cleanStores } from './clean-stores/index.js'
-export { computed, batched } from './computed/index.js'
+export { batched, computed } from './computed/index.js'
 export { deepMap, getPath, setPath } from './deep-map/index.js'
 export { keepMount } from './keep-mount/index.js'
 export {

--- a/keep-mount/index.d.ts
+++ b/keep-mount/index.d.ts
@@ -1,4 +1,5 @@
-import type { MapCreator, Store } from '../map/index.js'
+import type { MapCreator } from '../map-creator/index.js'
+import type { Store } from '../map/index.js'
 
 /**
  * Prevent destructor call for the store.

--- a/map-creator/index.d.ts
+++ b/map-creator/index.d.ts
@@ -1,0 +1,29 @@
+import type { MapStore } from '../map/index.js'
+
+export interface MapCreator<
+  Value extends object = any,
+  Args extends any[] = []
+> {
+  (id: string, ...args: Args): MapStore<Value>
+  build(id: string, ...args: Args): MapStore<Value>
+  cache: {
+    [id: string]: MapStore<Value & { id: string }>
+  }
+}
+
+/**
+ * Create function to create map stores. It will be like a class for store.
+ *
+ * @param init Store’s initializer. Returns store destructor.
+ */
+export function mapCreator<
+  Value extends object,
+  Args extends any[] = [],
+  StoreExt = {}
+>(
+  init?: (
+    store: MapStore<Value & { id: string }> & StoreExt,
+    id: string,
+    ...args: Args
+  ) => (() => void) | void
+): MapCreator<Value, Args>

--- a/map-creator/index.js
+++ b/map-creator/index.js
@@ -1,0 +1,38 @@
+import { clean } from '../clean-stores/index.js'
+import { onMount } from '../lifecycle/index.js'
+import { map } from '../map/index.js'
+
+export function mapCreator(init) {
+  let Creator = (id, ...args) => {
+    if (!Creator.cache[id]) {
+      Creator.cache[id] = Creator.build(id, ...args)
+    }
+    return Creator.cache[id]
+  }
+
+  Creator.build = (id, ...args) => {
+    let store = map({ id })
+    onMount(store, () => {
+      let destroy
+      if (init) destroy = init(store, id, ...args)
+      return () => {
+        delete Creator.cache[id]
+        if (destroy) destroy()
+      }
+    })
+    return store
+  }
+
+  Creator.cache = {}
+
+  if (process.env.NODE_ENV !== 'production') {
+    Creator[clean] = () => {
+      for (let id in Creator.cache) {
+        Creator.cache[id][clean]()
+      }
+      Creator.cache = {}
+    }
+  }
+
+  return Creator
+}

--- a/map-creator/index.test.ts
+++ b/map-creator/index.test.ts
@@ -1,0 +1,63 @@
+import { test } from 'uvu'
+import { equal, is } from 'uvu/assert'
+
+import { cleanStores, mapCreator } from '../index.js'
+
+test('creates map store with argument', () => {
+  let events = ''
+  let User = mapCreator<{ name: string }, [string]>(
+    (store, id, defaultName) => {
+      events += `init-${id} `
+      store.setKey('name', defaultName)
+      return () => {
+        events += `destroy-${id} `
+      }
+    }
+  )
+
+  let user1 = User('1', 'John')
+  let user2 = User('1', 'Bob')
+  let user3 = User('2', 'John')
+
+  is(user1, user2)
+  is.not(user1, user3)
+
+  equal(events, '')
+  user1.listen(() => {})
+  user2.listen(() => {})
+  user3.listen(() => {})
+
+  equal(user1.get(), { id: '1', name: 'John' })
+
+  equal(events, 'init-1 init-2 ')
+
+  cleanStores(user1)
+  equal(events, 'init-1 init-2 destroy-1 ')
+
+  let user4 = User('1', 'John')
+  user4.listen(() => {})
+  equal(events, 'init-1 init-2 destroy-1 init-1 ')
+
+  cleanStores(User)
+  equal(events, 'init-1 init-2 destroy-1 init-1 destroy-1 destroy-2 ')
+})
+
+test('creates map store with ID only', () => {
+  let events = ''
+  let User = mapCreator<{ name: string }>((store, id) => {
+    events += `init-${id} `
+    store.setKey('name', 'default')
+    return () => {
+      events += `destroy-${id} `
+    }
+  })
+
+  let user1 = User('1')
+  user1.listen(() => {})
+  equal(user1.get(), { id: '1', name: 'default' })
+
+  cleanStores(User)
+  equal(events, 'init-1 destroy-1 ')
+})
+
+test.run()

--- a/map/index.d.ts
+++ b/map/index.d.ts
@@ -125,14 +125,3 @@ export interface MapStore<Value extends object = any>
 export function map<Value extends object, StoreExt extends object = {}>(
   value?: Value
 ): MapStore<Value> & StoreExt
-
-export interface MapCreator<
-  Value extends object = any,
-  Args extends any[] = []
-> {
-  (id: string, ...args: Args): MapStore<Value>
-  build(id: string, ...args: Args): MapStore<Value>
-  cache: {
-    [id: string]: MapStore<Value & { id: string }>
-  }
-}

--- a/map/index.d.ts
+++ b/map/index.d.ts
@@ -131,6 +131,7 @@ export interface MapCreator<
   Args extends any[] = []
 > {
   (id: string, ...args: Args): MapStore<Value>
+  build(id: string, ...args: Args): MapStore<Value>
   cache: {
     [id: string]: MapStore<Value & { id: string }>
   }

--- a/map/index.js
+++ b/map/index.js
@@ -4,7 +4,7 @@ export let map = (value = {}) => {
   let $map = atom(value)
 
   $map.setKey = function (key, newVal) {
-    const oldVal = $map.value[key]
+    let oldVal = $map.value[key]
     if (typeof newVal === 'undefined' && key in $map.value) {
       $map.value = { ...$map.value }
       delete $map.value[key]

--- a/map/index.js
+++ b/map/index.js
@@ -5,17 +5,12 @@ export let map = (value = {}) => {
 
   $map.setKey = function (key, newVal) {
     let oldVal = $map.value[key]
+    if (oldVal === newVal) return
+    $map.value = { ...$map.value, [key]: newVal }
     if (typeof newVal === 'undefined' && key in $map.value) {
-      $map.value = { ...$map.value }
       delete $map.value[key]
-      $map.notify(oldVal, key)
-    } else if (oldVal !== newVal) {
-      $map.value = {
-        ...$map.value,
-        [key]: newVal,
-      }
-      $map.notify(oldVal, key)
     }
+    $map.notify(oldVal, key)
   }
 
   return $map

--- a/map/index.js
+++ b/map/index.js
@@ -3,19 +3,18 @@ import { atom } from '../atom/index.js'
 export let map = (value = {}) => {
   let $map = atom(value)
 
-  $map.setKey = function (key, newValue) {
-    if (typeof newValue === 'undefined') {
-      if (key in $map.value) {
-        $map.value = { ...$map.value }
-        delete $map.value[key]
-        $map.notify(key)
-      }
-    } else if ($map.value[key] !== newValue) {
+  $map.setKey = function (key, newVal) {
+    const oldVal = $map.value[key]
+    if (typeof newVal === 'undefined' && key in $map.value) {
+      $map.value = { ...$map.value }
+      delete $map.value[key]
+      $map.notify(oldVal, key)
+    } else if (oldVal !== newVal) {
       $map.value = {
         ...$map.value,
-        [key]: newValue
+        [key]: newVal,
       }
-      $map.notify(key)
+      $map.notify(oldVal, key)
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
       "import": {
         "./index.js": "{ map, computed, action }"
       },
-      "limit": "1013 B"
+      "limit": "1039 B"
     }
   ],
   "clean-publish": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "./package.json": "./package.json"
   },
   "engines": {
-    "node": "^16.0.0 || ^18.0.0 || >=20.0.0"
+    "node": "^18.0.0 || >=20.0.0"
   },
   "funding": [
     {

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
       "import": {
         "./index.js": "{ map, computed, action }"
       },
-      "limit": "1039 B"
+      "limit": "1045 B"
     }
   ],
   "clean-publish": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nanostores",
   "version": "0.9.3",
-  "description": "A tiny (301 bytes) state manager for React/Preact/Vue/Svelte with many atomic tree-shakable stores",
+  "description": "A tiny (302 bytes) state manager for React/Preact/Vue/Svelte with many atomic tree-shakable stores",
   "keywords": [
     "store",
     "state",
@@ -108,14 +108,14 @@
       "import": {
         "./index.js": "{ atom }"
       },
-      "limit": "301 B"
+      "limit": "302 B"
     },
     {
       "name": "All",
       "import": {
         "./index.js": "{ map, computed, action }"
       },
-      "limit": "1081 B"
+      "limit": "1085 B"
     }
   ],
   "clean-publish": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nanostores",
   "version": "0.9.3",
-  "description": "A tiny (297 bytes) state manager for React/Preact/Vue/Svelte with many atomic tree-shakable stores",
+  "description": "A tiny (301 bytes) state manager for React/Preact/Vue/Svelte with many atomic tree-shakable stores",
   "keywords": [
     "store",
     "state",
@@ -108,7 +108,7 @@
       "import": {
         "./index.js": "{ atom }"
       },
-      "limit": "297 B"
+      "limit": "301 B"
     },
     {
       "name": "All",

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
       "import": {
         "./index.js": "{ map, computed, action }"
       },
-      "limit": "1045 B"
+      "limit": "1081 B"
     }
   ],
   "clean-publish": {

--- a/task/index.d.ts
+++ b/task/index.d.ts
@@ -1,4 +1,7 @@
-export let taskSymbol: Symbol
+export class Task<Value> extends Promise<Value> {
+  t: true
+}
+
 /**
  * Track store async task by start/end functions.
  * It is useful for test to wait end of the processing.
@@ -39,7 +42,7 @@ export function startTask(): () => void
  */
 export function task<Return = never>(
   cb: () => Promise<Return> | Return
-): Promise<Return>
+): Task<Return>
 
 /**
  * Return Promise until all current tasks (and tasks created while waiting).

--- a/task/index.d.ts
+++ b/task/index.d.ts
@@ -1,3 +1,4 @@
+export let taskSymbol: Symbol
 /**
  * Track store async task by start/end functions.
  * It is useful for test to wait end of the processing.
@@ -25,7 +26,7 @@ export function startTask(): () => void
  * ```ts
  * import { task } from 'nanostores'
  *
- * function saveUser () {
+ * async function saveUser () {
  *   await task(async () => {
  *     await api.submit('/user', user.get())
  *     $user.setKey('saved', true)

--- a/task/index.js
+++ b/task/index.js
@@ -15,7 +15,9 @@ export function startTask() {
 
 export function task(cb) {
   let endTask = startTask()
-  return cb().finally(endTask)
+  let promise = cb().finally(endTask)
+  promise.t = true
+  return promise
 }
 
 export function allTasks() {

--- a/task/types.ts
+++ b/task/types.ts
@@ -1,4 +1,4 @@
-import { task } from '../index.js'
+import { atom, computed, task } from '../index.js'
 
 let a = await task(() => {
   return 1
@@ -13,3 +13,14 @@ let str: string = b
 let num: number = a
 
 console.log(str, num)
+
+let $origin = atom(1)
+let $result = computed($origin, origin =>
+  task(async () => {
+    return origin + 1
+  })
+)
+
+let result: number = $result.get()
+
+console.log(result)


### PR DESCRIPTION
:warning: this is a breaking change!

i'm opening this PR as a way to demonstrate a feature i'd like to have. it's not very heavy as you can see, and can help in many situations where we would like to compute diff between old and new value in userland.

currently, this is not possible easily. you need to hold the value at the end of a `.listen` and do the job manually, but i think this kind of api is very useful and comfortable (as in Vue the watchers have `(newVal?: T, oldVal?: T) => void`)

Current workaround:

```js
let oldVal = atom.get()

atom.subscribe(newVal => {
  const diff = newVal - oldVal
  oldVal = newVal
})
```