### PR TITLE
Readme: Clarify `useStore`

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,8 +139,9 @@ $counter.set($counter.get() + 1)
 ```
 
 `store.subscribe(cb)` and `store.listen(cb)` can be used to subscribe
-for the changes in vanilla JS. For React/Vue we have extra special helpers
-to re-render the component on any store changes.
+for the changes in vanilla JS. For [React](#react--preact)/[Vue](#vue)
+we have extra special helpers `useStore` to re-render the component on 
+any store changes.
 
 ```ts
 const unbindListener = $counter.subscribe(value => {


### PR DESCRIPTION
I miss read this section over and over again. I read is as "special helpers to re-render the component on any store changes:" where the next code section is this special helper. However, this was referring to `useStore` which is documented way below in the specific framework section.

This should clarify this issue and make sure users look for "`useStore`" in the doc.