### PR TITLE
Allow `undefined` in `setKey`

### DIFF
--- a/deep-map/index.d.ts
+++ b/deep-map/index.d.ts
@@ -34,7 +34,10 @@ export type DeepMapStore<T extends BaseDeepMap> = Omit<
    * @param key The key name. Attributes can be split with a dot `.` and `[]`.
    * @param value New value.
    */
-  setKey: <K extends AllPaths<T>>(key: K, value: FromPath<T, K>) => void
+  setKey: <K extends AllPaths<T>>(
+    key: K,
+    value: FromPath<T, K> | undefined
+  ) => void
 
   /**
    * Subscribe to store changes and call listener immediately.

--- a/deep-map/index.test.ts
+++ b/deep-map/index.test.ts
@@ -291,7 +291,7 @@ test('changes value object reference', () => {
 })
 
 test('deletes keys on undefined value', () => {
-  let $store = deepMap<{ a: number | undefined }>()
+  let $store = deepMap<{ a: number }>()
 
   let keys: string[][] = []
   $store.listen(value => {

--- a/map/index.d.ts
+++ b/map/index.d.ts
@@ -88,7 +88,7 @@ export interface MapStore<Value extends object = any>
    */
   setKey<Key extends AllKeys<Value>>(
     key: Key,
-    value: Get<Value, Key> | Value[Key]
+    value: Get<Value, Key> | undefined | Value[Key]
   ): void
 
   /**


### PR DESCRIPTION
To allow clearing a key when passing `undefined` as the value, we should add `undefined` to the parameter type signature.