### PR TITLE
docs: update expired link to Svelte's store contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -482,7 +482,7 @@ In other frameworks, Nano Stores promote code style to use `$` prefixes
 for store’s names. But in Svelte it has a special meaning, so we recommend
 to not follow this code style here.
 
-[Svelte's store contract]: https://svelte.dev/docs#component-format-script-4-prefix-stores-with-$-to-access-their-values-store-contract
+[Svelte's store contract]: https://svelte.dev/docs/svelte-components#script-4-prefix-stores-with-$-to-access-their-values
 
 
 ### Solid


### PR DESCRIPTION
Reading the docs I noticed that the link to the Svelte documentation describing its store contract was no longer valid, this updates the link.