### PR TITLE
fix: missed recalculation of `computed` with `deepMap` inside it

### DIFF
--- a/computed/index.test.ts
+++ b/computed/index.test.ts
@@ -369,14 +369,12 @@ test('supports map', () => {
   let mapValue: { counter: number } | undefined
   let computedMapValue: number | undefined
 
-  let unsubscribe = [
-    $map.subscribe(value => {
-      mapValue = value
-    }),
-    $computedMap.subscribe(value => {
-      computedMapValue = value
-    })
-  ]
+  let unsubscribeMap = $map.subscribe(value => {
+    mapValue = value
+  })
+  let unsubscribeComputedMap = $computedMap.subscribe(value => {
+    computedMapValue = value
+  })
 
   $map.set({
     counter: 2
@@ -388,9 +386,8 @@ test('supports map', () => {
   equal(mapValue, { counter: 3 })
   equal(computedMapValue, 4)
 
-  unsubscribe.forEach(i => {
-    i()
-  })
+  unsubscribeMap()
+  unsubscribeComputedMap()
 })
 
 test('supports deepMap', () => {
@@ -406,14 +403,12 @@ test('supports deepMap', () => {
   let deepMapValue: { item: { nested: number } } | undefined
   let computedDeepMapValue: number | undefined
 
-  let unsubscribe = [
-    $deepMap.subscribe(value => {
-      deepMapValue = value
-    }),
-    $computedDeepMap.subscribe(value => {
-      computedDeepMapValue = value
-    })
-  ]
+  let unsubscribeDeepMap = $deepMap.subscribe(value => {
+    deepMapValue = value
+  })
+  let unsubscribeComputedMap = $computedDeepMap.subscribe(value => {
+    computedDeepMapValue = value
+  })
 
   $deepMap.set({
     item: {
@@ -427,9 +422,8 @@ test('supports deepMap', () => {
   equal(deepMapValue, { item: { nested: 3 } })
   equal(computedDeepMapValue, 4)
 
-  unsubscribe.forEach(i => {
-    i()
-  })
+  unsubscribeDeepMap()
+  unsubscribeComputedMap()
 })
 
 test.run()

--- a/computed/index.test.ts
+++ b/computed/index.test.ts
@@ -5,6 +5,8 @@ import { equal, ok } from 'uvu/assert'
 import {
   atom,
   computed,
+  deepMap,
+  map,
   onMount,
   STORE_UNMOUNT_DELAY,
   type StoreValue
@@ -354,6 +356,80 @@ test('computes initial value when argument is undefined', () => {
   let $two = computed($one, (value: string | undefined) => !!value)
   equal($one.get(), undefined)
   equal($two.get(), false)
+})
+
+test('supports map', () => {
+  let $map = map({
+    counter: 1
+  })
+  let $computedMap = computed($map, value => {
+    return value.counter + 1
+  })
+
+  let mapValue: { counter: number } | undefined
+  let computedMapValue: number | undefined
+
+  let unsubscribe = [
+    $map.subscribe(value => {
+      mapValue = value
+    }),
+    $computedMap.subscribe(value => {
+      computedMapValue = value
+    })
+  ]
+
+  $map.set({
+    counter: 2
+  })
+  equal(mapValue, { counter: 2 })
+  equal(computedMapValue, 3)
+
+  $map.setKey('counter', 3)
+  equal(mapValue, { counter: 3 })
+  equal(computedMapValue, 4)
+
+  unsubscribe.forEach(i => {
+    i()
+  })
+})
+
+test('supports deepMap', () => {
+  let $deepMap = deepMap({
+    item: {
+      nested: 1
+    }
+  })
+  let $computedDeepMap = computed($deepMap, value => {
+    return value.item.nested + 1
+  })
+
+  let deepMapValue: { item: { nested: number } } | undefined
+  let computedDeepMapValue: number | undefined
+
+  let unsubscribe = [
+    $deepMap.subscribe(value => {
+      deepMapValue = value
+    }),
+    $computedDeepMap.subscribe(value => {
+      computedDeepMapValue = value
+    })
+  ]
+
+  $deepMap.set({
+    item: {
+      nested: 2
+    }
+  })
+  equal(deepMapValue, { item: { nested: 2 } })
+  equal(computedDeepMapValue, 3)
+
+  $deepMap.setKey('item.nested', 3)
+  equal(deepMapValue, { item: { nested: 3 } })
+  equal(computedDeepMapValue, 4)
+
+  unsubscribe.forEach(i => {
+    i()
+  })
 })
 
 test.run()

--- a/deep-map/index.js
+++ b/deep-map/index.js
@@ -7,7 +7,7 @@ export function deepMap(initial = {}) {
   let $deepMap = atom(initial)
   $deepMap.setKey = (key, value) => {
     if (getPath($deepMap.value, key) !== value) {
-      $deepMap.value = setPath($deepMap.value, key, value)
+      $deepMap.value = {...setPath($deepMap.value, key, value)}
       $deepMap.notify(key)
     }
   }


### PR DESCRIPTION
The problem was the lack of immutability as it works in `setKey()` of `map()`.