### PR TITLE
Add nested arrays support in path argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,16 +219,27 @@ export const $profile = deepMap({
       name: 'woodworking',
       friends: [{ id: 123, name: 'Ron Swanson' }]
     }
+  ],
+  skills: [
+    [
+      'Carpentry',
+      'Sanding'
+    ],
+    [
+      'Varnishing'
+    ]
   ]
 })
 
-listenKeys($profile, ['hobbies[0].friends[0].name'])
+listenKeys($profile, ['hobbies[0].friends[0].name', 'skills[0][0]'])
 
 // Won't fire subscription
 $profile.setKey('hobbies[0].name', 'Scrapbooking')
+$profile.setKey('skills[0][1]', 'Staining')
 
-// But this one will fire subscription
+// But those will fire subscription
 $profile.setKey('hobbies[0].friends[0].name', 'Leslie Knope')
+$profile.setKey('skills[0][0]', 'Whittling')
 ```
 
 

--- a/deep-map/path.d.ts
+++ b/deep-map/path.d.ts
@@ -40,6 +40,16 @@ export type AllPaths<
 
 type IsNumber<T extends string> = T extends `${number}` ? true : false
 
+type ElementType<T> = T extends (infer U)[] ? U : never
+
+type Unwrap<T, P> = P extends `[${infer I}]${infer R}`
+  ? [ElementType<T>, IsNumber<I>] extends [infer Item, true]
+    ? R extends ''
+      ? Item
+      : Unwrap<Item, R>
+    : never
+  : never
+
 type NestedObjKey<T, P> = P extends `${infer A}.${infer B}`
   ? A extends keyof T
     ? FromPath<NonNullable<T[A]>, B>
@@ -52,9 +62,13 @@ type NestedArrKey<T, P> = P extends `${infer A}[${infer I}]${infer R}`
       (infer Item)[],
       true
     ]
-    ? R extends `.${infer NewR}`
-      ? FromPath<Item, NewR>
-      : Item
+    ? R extends ''
+      ? Item
+      : R extends `.${infer NewR}`
+        ? FromPath<Item, NewR>
+        : R extends `${infer Indices}.${infer MoreR}`
+          ? FromPath<Unwrap<Item, Indices>, MoreR>
+          : Unwrap<Item, R>
     : never
   : never
 

--- a/deep-map/path.js
+++ b/deep-map/path.js
@@ -38,13 +38,15 @@ function setByKey(obj, splittedKeys, value) {
 const ARRAY_INDEX = /(.*)\[(\d+)\]/
 
 function getAllKeysFromPath(path) {
-  return path.split('.').flatMap(key => {
-    if (ARRAY_INDEX.test(key)) {
-      let res = key.match(ARRAY_INDEX)
-      return res.slice(1)
-    }
-    return [key]
-  })
+  return path.split('.').flatMap(key => getKeyAndIndicesFromKey(key))
+}
+
+function getKeyAndIndicesFromKey(key) {
+  if (ARRAY_INDEX.test(key)) {
+    let [, keyPart, index] = key.match(ARRAY_INDEX)
+    return [...getKeyAndIndicesFromKey(keyPart), index]
+  }
+  return [key]
 }
 
 function ensureKey(obj, key, nextKey) {

--- a/deep-map/path.test.ts
+++ b/deep-map/path.test.ts
@@ -6,13 +6,16 @@ import { getPath, setPath } from './path.js'
 test('path evaluates correct value', () => {
   let exampleObj = {
     a: '123',
-    b: { c: 123, d: [{ e: 123 }] }
+    b: { c: 123, d: [{ e: 123 }] },
+    f: [[1, 2], [{g: 3}, 4]],
   }
 
   equal(getPath(exampleObj, 'a'), '123')
   equal(getPath(exampleObj, 'b.c'), 123)
   equal(getPath(exampleObj, 'b.d[0]'), { e: 123 })
   equal(getPath(exampleObj, 'b.d[0].e'), 123)
+  equal(getPath(exampleObj, 'f[0][1]'), 2)
+  equal(getPath(exampleObj, 'f[1][0].g'), 3)
 
   // @ts-expect-error: incorrect key here
   equal(getPath(exampleObj, 'abra.cadabra.booms'), undefined)
@@ -29,8 +32,21 @@ test('simple path setting', () => {
   let initial: TestObj = { a: { e: 123 }, f: '' }
 
   initial = setPath(initial, 'f', 'hey')
-  initial = setPath(initial, 'f', 'hey')
   equal(initial, { a: { e: 123 }, f: 'hey' })
+})
+
+test('nested arrays path setting', () => {
+  type TestObj = {
+    a: {
+      b: {c: number}[][][]
+      d: { e: string }[][]
+    }[]
+  }
+  let initial: TestObj = { a: [{ b: [[[{ c: 1 }]]], d: [[{e: 'val1'}]] }] }
+
+  initial = setPath(initial, 'a[0].b[0][0][0].c', 2)
+  initial = setPath(initial, 'a[0].d[0][1]', {e: 'val2'})
+  equal(initial, { a: [{ b: [[[{ c: 2 }]]], d: [[{e: 'val1'}, {e: 'val2'}]] }] })
 })
 
 test('creating objects', () => {

--- a/listen-keys/index.test.ts
+++ b/listen-keys/index.test.ts
@@ -32,7 +32,7 @@ test('listen for specific keys', () => {
 
 test('allows setting specific deep keys', () => {
   let events: string[] = []
-  let $store = deepMap({ a: { b: { c: { d: [1] } }, e: 1 } })
+  let $store = deepMap({ a: { b: { c: { d: [1] } }, e: 1, f: [[{ g: 1 }]] } })
 
   listenKeys($store, ['a.e'], value => {
     events.push(`e${value.a.e}`)
@@ -43,12 +43,17 @@ test('allows setting specific deep keys', () => {
   listenKeys($store, ['a.b.c.d[1]'], value => {
     events.push(`d[1]${value.a.b.c.d[1]}`)
   })
+  listenKeys($store, ['a.f[0][0].g'], value => {
+    events.push(`g${value.a.f[0][0].g}`)
+  })
 
   $store.setKey('a.e', 2)
   $store.setKey('a.b.c.d', [2])
   $store.setKey('a.b.c.d[0]', 3)
   $store.setKey('a.b.c.d[1]', 4)
-  equal(events, ['e2', 'd[2]', 'd[1]4'])
+  $store.setKey('a.f[0][1]', {g: 0})
+  $store.setKey('a.f[0][0].g', 5)
+  equal(events, ['e2', 'd[2]', 'd[1]4', 'g5'])
 })
 
 test.run()


### PR DESCRIPTION
Fixes https://github.com/nanostores/nanostores/issues/253

Added support for nested array access in path functions.
Added types of nested arrays in paths.
Updated deepMap example in README.
Added tests for setPath and setKey with nested arrays.