### PR TITLE
feat!: Update computed values before other listeners

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A tiny state manager for **React**, **React Native**, **Preact**, **Vue**,
 **Svelte**, **Solid**, **Lit**, **Angular**, and vanilla JS.
 It uses **many atomic stores** and direct manipulation.
 
-* **Small.** Between 278 and 804 bytes (minified and brotlied).
+* **Small.** Between 278 and 807 bytes (minified and brotlied).
   Zero dependencies. It uses [Size Limit] to control size.
 * **Fast.** With small atomic and derived stores, you do not need to call
   the selector function for all components on every store change.

--- a/computed/index.js
+++ b/computed/index.js
@@ -17,7 +17,8 @@ let computedStore = (stores, cb, batched) => {
       let value = cb(...args)
       if (value && value.then && value.t) {
         value.then(asyncValue => {
-          if (runId === currentRunId) { // Prevent a stale set
+          if (runId === currentRunId) {
+            // Prevent a stale set
             $computed.set(asyncValue)
           }
         })
@@ -37,7 +38,7 @@ let computedStore = (stores, cb, batched) => {
     : set
 
   onMount($computed, () => {
-    let unbinds = stores.map($store => $store.listen(run, $computed.l))
+    let unbinds = stores.map($store => $store.listen(run, -1 / $computed.l))
     set()
     return () => {
       for (let unbind of unbinds) unbind()

--- a/computed/index.test.ts
+++ b/computed/index.test.ts
@@ -491,3 +491,19 @@ test('async computed using task', async () => {
     [10, 20]
   ])
 })
+
+test('computed values update first', () => {
+  let $atom = atom(1)
+  let $computed = computed($atom, value => value * 2)
+  let values: (number | string)[] = []
+  $atom.subscribe(value => {
+    values.push(value)
+    values.push($computed.get())
+  })
+  $computed.subscribe(() => {
+    values.push('afterAtom')
+  })
+  deepStrictEqual(values, [1, 2, 'afterAtom'])
+  $atom.set(2)
+  deepStrictEqual(values, [1, 2, 'afterAtom', 2, 4, 'afterAtom'])
+})

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
       "import": {
         "./index.js": "{ map, computed, }"
       },
-      "limit": "804 B"
+      "limit": "807 B"
     }
   ],
   "clean-publish": {


### PR DESCRIPTION
An idea that sprouted from the discussion here: https://github.com/orgs/nanostores/discussions/265.

When using computed values in listeners of the values they depend on the computed have stale values. This PR changes the priority of the value updates for computed values to be lower than the original atom without changing the priority of the listeners of the computed values.

(Sidenote: how are the functions included in the "All" size check decided? It's not including things like deepMap and listenKeys?)