### PR TITLE
feat: add subscribeKeys function

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,9 +163,9 @@ const unbindListener = $counter.subscribe((value, oldValue) => {
 ```
 
 `store.subscribe(cb)` in contrast with `store.listen(cb)` also call listeners
-immediately during the subscription. Note that the initial call for `store.
-subscribe(cb)` will not have any previous value and `oldValue`
-will be `undefined`.
+immediately during the subscription.
+Note that the initial call for `store.subscribe(cb)` will not have any
+previous value and `oldValue` will be `undefined`.
 
 [router]: https://github.com/nanostores/router
 
@@ -218,6 +218,19 @@ $profile.listen((profile, oldProfile, changed) => {
 })
 ```
 
+You can also listen for specific keys of the store being changed, using
+`listenKeys` and `subscribeKeys`.
+
+```ts
+listenKeys($profile, ['name'], (value, oldValue, changed) => {
+  console.log(`$profile.Name new value ${value.name}`)
+})
+```
+
+`subscribeKeys(store, keys, cb)` in contrast with `listenKeys(store, keys, cb)`
+also call listeners immediately during the subscription.
+Please note that when using subscribe for store changes, the initial evaluation
+of the callback has undefined old value and changed key.
 
 ### Deep Maps
 

--- a/README.md
+++ b/README.md
@@ -7,14 +7,14 @@ A tiny state manager for **React**, **React Native**, **Preact**, **Vue**,
 **Svelte**, **Solid**, **Lit**, **Angular**, and vanilla JS.
 It uses **many atomic stores** and direct manipulation.
 
-- **Small.** Between 287 and 818 bytes (minified and brotlied).
+* **Small.** Between 287 and 818 bytes (minified and brotlied).
   Zero dependencies. It uses [Size Limit] to control size.
-- **Fast.** With small atomic and derived stores, you do not need to call
+* **Fast.** With small atomic and derived stores, you do not need to call
   the selector function for all components on every store change.
-- **Tree Shakable.** A chunk contains only stores used by components
+* **Tree Shakable.** A chunk contains only stores used by components
   in the chunk.
-- Designed to move logic from components to stores.
-- Good **TypeScript** support.
+* Designed to move logic from components to stores.
+* Good **TypeScript** support.
 
 ```ts
 // store/users.ts
@@ -23,7 +23,7 @@ import { atom } from 'nanostores'
 export const $users = atom<User[]>([])
 
 export function addUser(user: User) {
-  $users.set([...$users.get(), user])
+  $users.set([...$users.get(), user]);
 }
 ```
 
@@ -44,9 +44,7 @@ export const Admins = () => {
   const admins = useStore($admins)
   return (
     <ul>
-      {admins.map(user => (
-        <UserItem user={user} />
-      ))}
+      {admins.map(user => <UserItem user={user} />)}
     </ul>
   )
 }
@@ -58,25 +56,27 @@ export const Admins = () => {
 
 ---
 
-[Size Limit]: https://github.com/ai/size-limit
+[Size Limit]: https://github.com/ai/size-limit
+
 
 ## Table of Contents
 
-- [Smart Stores](#smart-stores)
-- [Devtools](#devtools)
-- [Guide](#guide)
-- Integration
-  - [React & Preact](#react--preact)
-  - [Vue](#vue)
-  - [Svelte](#svelte)
-  - [Solid](#solid)
-  - [Lit](#lit)
-  - [Angular](#angular)
-  - [Vanilla JS](#vanilla-js)
-  - [Server-Side Rendering](#server-side-rendering)
-  - [Tests](#tests)
-- [Best Practices](#best-practices)
-- [Known Issues](#known-issues)
+* [Smart Stores](#smart-stores)
+* [Devtools](#devtools)
+* [Guide](#guide)
+* Integration
+  * [React & Preact](#react--preact)
+  * [Vue](#vue)
+  * [Svelte](#svelte)
+  * [Solid](#solid)
+  * [Lit](#lit)
+  * [Angular](#angular)
+  * [Vanilla JS](#vanilla-js)
+  * [Server-Side Rendering](#server-side-rendering)
+  * [Tests](#tests)
+* [Best Practices](#best-practices)
+* [Known Issues](#known-issues)
+
 
 ## Install
 
@@ -84,25 +84,28 @@ export const Admins = () => {
 npm install nanostores
 ```
 
+
 ## Smart Stores
 
-- [Persistent](https://github.com/nanostores/persistent) store to save data
+* [Persistent](https://github.com/nanostores/persistent) store to save data
   to `localStorage` and synchronize changes between browser tabs.
-- [Router](https://github.com/nanostores/router) store to parse URL
+* [Router](https://github.com/nanostores/router) store to parse URL
   and implements SPA navigation.
-- [I18n](https://github.com/nanostores/i18n) library based on stores
+* [I18n](https://github.com/nanostores/i18n) library based on stores
   to make application translatable.
-- [Query](https://github.com/nanostores/query) store that helps you with smart
+* [Query](https://github.com/nanostores/query) store that helps you with smart
   remote data fetching.
-- [Logux Client](https://github.com/logux/client): stores with WebSocket
+* [Logux Client](https://github.com/logux/client): stores with WebSocket
   sync and CRDT conflict resolution.
+
 
 ## Devtools
 
-- [Logger](https://github.com/nanostores/logger) of lifecycles, changes
+* [Logger](https://github.com/nanostores/logger) of lifecycles, changes
   in the browser console.
-- [Vue Devtools](https://github.com/nanostores/vue#devtools) plugin that detects
+* [Vue Devtools](https://github.com/nanostores/vue#devtools) plugin that detects
   stores and attaches them to devtools inspectors and timeline.
+
 
 ## Guide
 
@@ -166,6 +169,7 @@ previous value and `oldValue` will be `undefined`.
 
 [router]: https://github.com/nanostores/router
 
+
 ### Maps
 
 Map store can be used to store objects with one level of depth and change keys
@@ -185,7 +189,7 @@ In TypeScript you can pass type parameter with store’s type:
 
 ```ts
 export interface ProfileValue {
-  name: string
+  name: string,
   email?: string
 }
 
@@ -228,6 +232,7 @@ also call listeners immediately during the subscription.
 Please note that when using subscribe for store changes, the initial evaluation
 of the callback has undefined old value and changed key.
 
+
 ### Deep Maps
 
 Deep maps work the same as `map`, but it supports arbitrary nesting of objects
@@ -243,7 +248,15 @@ export const $profile = deepMap({
       friends: [{ id: 123, name: 'Ron Swanson' }]
     }
   ],
-  skills: [['Carpentry', 'Sanding'], ['Varnishing']]
+  skills: [
+    [
+      'Carpentry',
+      'Sanding'
+    ],
+    [
+      'Varnishing'
+    ]
+  ]
 })
 
 listenKeys($profile, ['hobbies[0].friends[0].name', 'skills[0][0]'])
@@ -257,12 +270,13 @@ $profile.setKey('hobbies[0].friends[0].name', 'Leslie Knope')
 $profile.setKey('skills[0][0]', 'Whittling')
 ```
 
+
 ### Lazy Stores
 
 A unique feature of Nano Stores is that every state has two modes:
 
-- **Mount:** when one or more listeners is mounted to the store.
-- **Disabled:** when store has no listeners.
+* **Mount:** when one or more listeners is mounted to the store.
+* **Disabled:** when store has no listeners.
 
 Nano Stores was created to move logic from components to the store.
 Stores can listen for URL changes or establish network connections.
@@ -302,6 +316,7 @@ it('is anonymous from the beginning', () => {
 })
 ```
 
+
 ### Computed Stores
 
 Computed store is based on other store’s value.
@@ -323,12 +338,10 @@ import { computed, task } from 'nanostores'
 
 import { $userId } from './users.js'
 
-export const $user = computed($userId, userId =>
-  task(async () => {
-    const response = await fetch(`https://my-api/users/${userId}`)
-    return response.json()
-  })
-)
+export const $user = computed($userId, userId => task(async () => {
+  const response = await fetch(`https://my-api/users/${userId}`)
+  return response.json()
+}))
 ```
 
 By default, `computed` stores update _each_ time any of their dependencies
@@ -347,7 +360,7 @@ export const $link = batched([$sortBy, $categoryId], (sortBy, categoryId) => {
 })
 
 // `batched` will update only once even you changed two stores
-export function resetFilters() {
+export function resetFilters () {
   $sortBy.set('date')
   $categoryIdFilter.set('1')
 }
@@ -363,6 +376,7 @@ export const $newPosts = computed([$lastVisit, $posts], (lastVisit, posts) => {
   return posts.filter(post => post.publishedAt > lastVisit)
 })
 ```
+
 
 ### Tasks
 
@@ -390,19 +404,20 @@ await allTasks()
 const html = ReactDOMServer.renderToString(<App />)
 ```
 
+
 ### Store Events
 
 Each store has a few events, which you listen:
 
-- `onMount(store, cb)`: first listener was subscribed with debounce.
+* `onMount(store, cb)`: first listener was subscribed with debounce.
   We recommend to always use `onMount` instead of `onStart + onStop`,
   because it has a short delay to prevent flickering behavior.
-- `onStart(store, cb)`: first listener was subscribed. Low-level method.
+* `onStart(store, cb)`: first listener was subscribed. Low-level method.
   It is better to use `onMount` for simple lazy stores.
-- `onStop(store, cb)`: last listener was unsubscribed. Low-level method.
+* `onStop(store, cb)`: last listener was unsubscribed. Low-level method.
   It is better to use `onMount` for simple lazy stores.
-- `onSet(store, cb)`: before applying any changes to the store.
-- `onNotify(store, cb)`: before notifying store’s listeners about changes.
+* `onSet(store, cb)`: before applying any changes to the store.
+* `onNotify(store, cb)`: before notifying store’s listeners about changes.
 
 `onSet` and `onNotify` events has `abort()` function to prevent changes
 or notification.
@@ -418,6 +433,7 @@ onSet($store, ({ newValue, abort }) => {
 ```
 
 Event listeners can communicate with `payload.shared` object.
+
 
 ## Integration
 
@@ -439,6 +455,7 @@ export const Header = ({ postId }) => {
 
 [`@nanostores/preact`]: https://github.com/nanostores/preact
 [`@nanostores/react`]: https://github.com/nanostores/react
+
 
 ### Vue
 
@@ -462,6 +479,7 @@ const profile = useStore($profile)
 
 [`@nanostores/vue`]: https://github.com/nanostores/vue
 
+
 ### Svelte
 
 Every store implements [Svelte's store contract]. Put `$` before store variable
@@ -481,6 +499,7 @@ to not follow this code style here.
 
 [Svelte's store contract]: https://svelte.dev/docs/svelte-components#script-4-prefix-stores-with-$-to-access-their-values
 
+
 ### Solid
 
 Use [`@nanostores/solid`] and `useStore()` composable function
@@ -497,6 +516,7 @@ export function Header({ postId }) {
 ```
 
 [`@nanostores/solid`]: https://github.com/nanostores/solid
+
 
 ### Lit
 
@@ -520,6 +540,7 @@ class MyElement extends LitElement {
 ```
 
 [`@nanostores/lit`]: https://github.com/nanostores/lit
+
 
 ### Angular
 
@@ -545,19 +566,19 @@ import { profile } from '../stores/profile'
 import { IUser, User } from '../stores/user'
 
 @Component({
-  selector: 'app-root',
+  selector: "app-root",
   template: '<p *ngIf="(currentUser$ | async) as user">{{ user.name }}</p>'
 })
 export class AppComponent {
-  currentUser$: Observable<IUser> = this.nanostores
-    .useStore(profile)
+  currentUser$: Observable<IUser> = this.nanostores.useStore(profile)
     .pipe(switchMap(userId => this.nanostores.useStore(User(userId))))
 
-  constructor(private nanostores: NanostoresService) {}
+  constructor(private nanostores: NanostoresService) { }
 }
 ```
 
 [`@nanostores/angular`]: https://github.com/nanostores/angular
+
 
 ### Vanilla JS
 
@@ -576,7 +597,7 @@ $profile.subscribe(profile => {
 useful for a multiple stores listeners.
 
 ```js
-function render() {
+function render () {
   console.log(`${$post.get().title} for ${$profile.get().name}`)
 }
 
@@ -587,6 +608,7 @@ render()
 
 See also `listenKeys(store, keys, cb)` to listen for specific keys changes
 in the map.
+
 
 ### Server-Side Rendering
 
@@ -610,6 +632,7 @@ await allTasks()
 
 const html = ReactDOMServer.renderToString(<App />)
 ```
+
 
 ### Tests
 
@@ -642,6 +665,7 @@ it('saves user', async () => {
   expect(analyticsEvents.get()).toEqual(['user:save'])
 })
 ```
+
 
 ## Best Practices
 
@@ -686,6 +710,7 @@ With application logic in the stores, it is much easier to write and run tests.
 It is also easy to change your UI framework. For instance, add React Native
 version of the application.
 
+
 ### Separate changes and reaction
 
 Use a separated listener to react on new store’s value, not an action function
@@ -707,6 +732,7 @@ For instance, persistent store could get the new value from another browser tab.
 
 With this separation your UI will be ready to any source of store’s changes.
 
+
 ### Reduce `get()` usage outside of tests
 
 `get()` returns current value and it is a good solution for tests.
@@ -718,6 +744,7 @@ to subscribe to store changes and always render the actual data.
 - const { userId } = $profile.get()
 + const { userId } = useStore($profile)
 ```
+
 
 ## Known Issues
 

--- a/README.md
+++ b/README.md
@@ -7,14 +7,14 @@ A tiny state manager for **React**, **React Native**, **Preact**, **Vue**,
 **Svelte**, **Solid**, **Lit**, **Angular**, and vanilla JS.
 It uses **many atomic stores** and direct manipulation.
 
-* **Small.** Between 286 and 818 bytes (minified and brotlied).
+- **Small.** Between 287 and 818 bytes (minified and brotlied).
   Zero dependencies. It uses [Size Limit] to control size.
-* **Fast.** With small atomic and derived stores, you do not need to call
+- **Fast.** With small atomic and derived stores, you do not need to call
   the selector function for all components on every store change.
-* **Tree Shakable.** A chunk contains only stores used by components
+- **Tree Shakable.** A chunk contains only stores used by components
   in the chunk.
-* Designed to move logic from components to stores.
-* Good **TypeScript** support.
+- Designed to move logic from components to stores.
+- Good **TypeScript** support.
 
 ```ts
 // store/users.ts
@@ -23,7 +23,7 @@ import { atom } from 'nanostores'
 export const $users = atom<User[]>([])
 
 export function addUser(user: User) {
-  $users.set([...$users.get(), user]);
+  $users.set([...$users.get(), user])
 }
 ```
 
@@ -44,7 +44,9 @@ export const Admins = () => {
   const admins = useStore($admins)
   return (
     <ul>
-      {admins.map(user => <UserItem user={user} />)}
+      {admins.map(user => (
+        <UserItem user={user} />
+      ))}
     </ul>
   )
 }
@@ -56,27 +58,25 @@ export const Admins = () => {
 
 ---
 
-[Size Limit]: https://github.com/ai/size-limit
-
+[Size Limit]: https://github.com/ai/size-limit
 
 ## Table of Contents
 
-* [Smart Stores](#smart-stores)
-* [Devtools](#devtools)
-* [Guide](#guide)
-* Integration
-  * [React & Preact](#react--preact)
-  * [Vue](#vue)
-  * [Svelte](#svelte)
-  * [Solid](#solid)
-  * [Lit](#lit)
-  * [Angular](#angular)
-  * [Vanilla JS](#vanilla-js)
-  * [Server-Side Rendering](#server-side-rendering)
-  * [Tests](#tests)
-* [Best Practices](#best-practices)
-* [Known Issues](#known-issues)
-
+- [Smart Stores](#smart-stores)
+- [Devtools](#devtools)
+- [Guide](#guide)
+- Integration
+  - [React & Preact](#react--preact)
+  - [Vue](#vue)
+  - [Svelte](#svelte)
+  - [Solid](#solid)
+  - [Lit](#lit)
+  - [Angular](#angular)
+  - [Vanilla JS](#vanilla-js)
+  - [Server-Side Rendering](#server-side-rendering)
+  - [Tests](#tests)
+- [Best Practices](#best-practices)
+- [Known Issues](#known-issues)
 
 ## Install
 
@@ -84,28 +84,25 @@ export const Admins = () => {
 npm install nanostores
 ```
 
-
 ## Smart Stores
 
-* [Persistent](https://github.com/nanostores/persistent) store to save data
+- [Persistent](https://github.com/nanostores/persistent) store to save data
   to `localStorage` and synchronize changes between browser tabs.
-* [Router](https://github.com/nanostores/router) store to parse URL
+- [Router](https://github.com/nanostores/router) store to parse URL
   and implements SPA navigation.
-* [I18n](https://github.com/nanostores/i18n) library based on stores
+- [I18n](https://github.com/nanostores/i18n) library based on stores
   to make application translatable.
-* [Query](https://github.com/nanostores/query) store that helps you with smart
+- [Query](https://github.com/nanostores/query) store that helps you with smart
   remote data fetching.
-* [Logux Client](https://github.com/logux/client): stores with WebSocket
+- [Logux Client](https://github.com/logux/client): stores with WebSocket
   sync and CRDT conflict resolution.
-
 
 ## Devtools
 
-* [Logger](https://github.com/nanostores/logger) of lifecycles, changes
+- [Logger](https://github.com/nanostores/logger) of lifecycles, changes
   in the browser console.
-* [Vue Devtools](https://github.com/nanostores/vue#devtools) plugin that detects
+- [Vue Devtools](https://github.com/nanostores/vue#devtools) plugin that detects
   stores and attaches them to devtools inspectors and timeline.
-
 
 ## Guide
 
@@ -169,7 +166,6 @@ previous value and `oldValue` will be `undefined`.
 
 [router]: https://github.com/nanostores/router
 
-
 ### Maps
 
 Map store can be used to store objects with one level of depth and change keys
@@ -189,7 +185,7 @@ In TypeScript you can pass type parameter with store’s type:
 
 ```ts
 export interface ProfileValue {
-  name: string,
+  name: string
   email?: string
 }
 
@@ -247,15 +243,7 @@ export const $profile = deepMap({
       friends: [{ id: 123, name: 'Ron Swanson' }]
     }
   ],
-  skills: [
-    [
-      'Carpentry',
-      'Sanding'
-    ],
-    [
-      'Varnishing'
-    ]
-  ]
+  skills: [['Carpentry', 'Sanding'], ['Varnishing']]
 })
 
 listenKeys($profile, ['hobbies[0].friends[0].name', 'skills[0][0]'])
@@ -269,13 +257,12 @@ $profile.setKey('hobbies[0].friends[0].name', 'Leslie Knope')
 $profile.setKey('skills[0][0]', 'Whittling')
 ```
 
-
 ### Lazy Stores
 
 A unique feature of Nano Stores is that every state has two modes:
 
-* **Mount:** when one or more listeners is mounted to the store.
-* **Disabled:** when store has no listeners.
+- **Mount:** when one or more listeners is mounted to the store.
+- **Disabled:** when store has no listeners.
 
 Nano Stores was created to move logic from components to the store.
 Stores can listen for URL changes or establish network connections.
@@ -315,7 +302,6 @@ it('is anonymous from the beginning', () => {
 })
 ```
 
-
 ### Computed Stores
 
 Computed store is based on other store’s value.
@@ -337,10 +323,12 @@ import { computed, task } from 'nanostores'
 
 import { $userId } from './users.js'
 
-export const $user = computed($userId, userId => task(async () => {
-  const response = await fetch(`https://my-api/users/${userId}`)
-  return response.json()
-}))
+export const $user = computed($userId, userId =>
+  task(async () => {
+    const response = await fetch(`https://my-api/users/${userId}`)
+    return response.json()
+  })
+)
 ```
 
 By default, `computed` stores update _each_ time any of their dependencies
@@ -359,7 +347,7 @@ export const $link = batched([$sortBy, $categoryId], (sortBy, categoryId) => {
 })
 
 // `batched` will update only once even you changed two stores
-export function resetFilters () {
+export function resetFilters() {
   $sortBy.set('date')
   $categoryIdFilter.set('1')
 }
@@ -375,7 +363,6 @@ export const $newPosts = computed([$lastVisit, $posts], (lastVisit, posts) => {
   return posts.filter(post => post.publishedAt > lastVisit)
 })
 ```
-
 
 ### Tasks
 
@@ -403,20 +390,19 @@ await allTasks()
 const html = ReactDOMServer.renderToString(<App />)
 ```
 
-
 ### Store Events
 
 Each store has a few events, which you listen:
 
-* `onMount(store, cb)`: first listener was subscribed with debounce.
+- `onMount(store, cb)`: first listener was subscribed with debounce.
   We recommend to always use `onMount` instead of `onStart + onStop`,
   because it has a short delay to prevent flickering behavior.
-* `onStart(store, cb)`: first listener was subscribed. Low-level method.
+- `onStart(store, cb)`: first listener was subscribed. Low-level method.
   It is better to use `onMount` for simple lazy stores.
-* `onStop(store, cb)`: last listener was unsubscribed. Low-level method.
+- `onStop(store, cb)`: last listener was unsubscribed. Low-level method.
   It is better to use `onMount` for simple lazy stores.
-* `onSet(store, cb)`: before applying any changes to the store.
-* `onNotify(store, cb)`: before notifying store’s listeners about changes.
+- `onSet(store, cb)`: before applying any changes to the store.
+- `onNotify(store, cb)`: before notifying store’s listeners about changes.
 
 `onSet` and `onNotify` events has `abort()` function to prevent changes
 or notification.
@@ -432,7 +418,6 @@ onSet($store, ({ newValue, abort }) => {
 ```
 
 Event listeners can communicate with `payload.shared` object.
-
 
 ## Integration
 
@@ -454,7 +439,6 @@ export const Header = ({ postId }) => {
 
 [`@nanostores/preact`]: https://github.com/nanostores/preact
 [`@nanostores/react`]: https://github.com/nanostores/react
-
 
 ### Vue
 
@@ -478,7 +462,6 @@ const profile = useStore($profile)
 
 [`@nanostores/vue`]: https://github.com/nanostores/vue
 
-
 ### Svelte
 
 Every store implements [Svelte's store contract]. Put `$` before store variable
@@ -498,7 +481,6 @@ to not follow this code style here.
 
 [Svelte's store contract]: https://svelte.dev/docs/svelte-components#script-4-prefix-stores-with-$-to-access-their-values
 
-
 ### Solid
 
 Use [`@nanostores/solid`] and `useStore()` composable function
@@ -515,7 +497,6 @@ export function Header({ postId }) {
 ```
 
 [`@nanostores/solid`]: https://github.com/nanostores/solid
-
 
 ### Lit
 
@@ -539,7 +520,6 @@ class MyElement extends LitElement {
 ```
 
 [`@nanostores/lit`]: https://github.com/nanostores/lit
-
 
 ### Angular
 
@@ -565,19 +545,19 @@ import { profile } from '../stores/profile'
 import { IUser, User } from '../stores/user'
 
 @Component({
-  selector: "app-root",
+  selector: 'app-root',
   template: '<p *ngIf="(currentUser$ | async) as user">{{ user.name }}</p>'
 })
 export class AppComponent {
-  currentUser$: Observable<IUser> = this.nanostores.useStore(profile)
+  currentUser$: Observable<IUser> = this.nanostores
+    .useStore(profile)
     .pipe(switchMap(userId => this.nanostores.useStore(User(userId))))
 
-  constructor(private nanostores: NanostoresService) { }
+  constructor(private nanostores: NanostoresService) {}
 }
 ```
 
 [`@nanostores/angular`]: https://github.com/nanostores/angular
-
 
 ### Vanilla JS
 
@@ -596,7 +576,7 @@ $profile.subscribe(profile => {
 useful for a multiple stores listeners.
 
 ```js
-function render () {
+function render() {
   console.log(`${$post.get().title} for ${$profile.get().name}`)
 }
 
@@ -607,7 +587,6 @@ render()
 
 See also `listenKeys(store, keys, cb)` to listen for specific keys changes
 in the map.
-
 
 ### Server-Side Rendering
 
@@ -631,7 +610,6 @@ await allTasks()
 
 const html = ReactDOMServer.renderToString(<App />)
 ```
-
 
 ### Tests
 
@@ -664,7 +642,6 @@ it('saves user', async () => {
   expect(analyticsEvents.get()).toEqual(['user:save'])
 })
 ```
-
 
 ## Best Practices
 
@@ -709,7 +686,6 @@ With application logic in the stores, it is much easier to write and run tests.
 It is also easy to change your UI framework. For instance, add React Native
 version of the application.
 
-
 ### Separate changes and reaction
 
 Use a separated listener to react on new store’s value, not an action function
@@ -731,7 +707,6 @@ For instance, persistent store could get the new value from another browser tab.
 
 With this separation your UI will be ready to any source of store’s changes.
 
-
 ### Reduce `get()` usage outside of tests
 
 `get()` returns current value and it is a good solution for tests.
@@ -743,7 +718,6 @@ to subscribe to store changes and always render the actual data.
 - const { userId } = $profile.get()
 + const { userId } = useStore($profile)
 ```
-
 
 ## Known Issues
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -19,7 +19,7 @@ export {
   onStop,
   STORE_UNMOUNT_DELAY
 } from './lifecycle/index.js'
-export { listenKeys } from './listen-keys/index.js'
+export { listenKeys, subscribeKeys } from './listen-keys/index.js'
 export { mapCreator, MapCreator } from './map-creator/index.js'
 export {
   AnyStore,

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ export {
   onStop,
   STORE_UNMOUNT_DELAY
 } from './lifecycle/index.js'
-export { listenKeys } from './listen-keys/index.js'
+export { listenKeys, subscribeKeys } from './listen-keys/index.js'
 export { mapCreator } from './map-creator/index.js'
 export { map } from './map/index.js'
 export { allTasks, cleanTasks, startTask, task } from './task/index.js'

--- a/listen-keys/index.d.ts
+++ b/listen-keys/index.d.ts
@@ -56,7 +56,6 @@ export function listenKeys<
  * @param keys The keys to listen.
  * @param listener Standard listener.
  */
-
 export function subscribeKeys<
   SomeStore extends { setKey: (key: any, value: any) => void }
 >(

--- a/listen-keys/index.d.ts
+++ b/listen-keys/index.d.ts
@@ -3,11 +3,15 @@ import type { StoreValue } from '../map/index.js'
 /**
  * Listen for specific keys of the store.
  *
+ * In contrast with {@link subscribeKeys} it do not call listener
+ * immediately.
  * ```js
  * import { listenKeys } from 'nanostores'
  *
- * listenKeys($page, ['blocked'], () => {
- *   console.log('You has no access')
+ * listenKeys($page, ['blocked'], (value, oldValue, changed) => {
+ *   if (value.blocked) {
+ *     console.log('You has no access')
+ *   }
  * })
  * ```
  *
@@ -25,6 +29,43 @@ export function listenKeys<
   listener: (
     value: StoreValue<SomeStore>,
     oldValue: StoreValue<SomeStore>,
+    changed: SomeStore extends {
+      setKey: (key: infer Key, value: never) => unknown
+    }
+      ? Key[]
+      : never
+  ) => void
+): () => void
+
+/**
+ * Listen for specific keys of the store and call listener immediately.
+ * Note that the oldValue and changed arguments in the listener are
+ * undefined during the initial call.
+ *
+ * ```js
+ * import { subscribeKeys } from 'nanostores'
+ *
+ * subscribeKeys($page, ['blocked'], (value, oldValue, changed) => {
+ *   if (value.blocked) {
+ *     console.log('You has no access')
+ *   }
+ * })
+ * ```
+ *
+ * @param $store The store to listen.
+ * @param keys The keys to listen.
+ * @param listener Standard listener.
+ */
+
+export function subscribeKeys<
+  SomeStore extends { setKey: (key: any, value: any) => void }
+>(
+  $store: SomeStore,
+  keys: SomeStore extends { setKey: (key: infer Key, value: never) => unknown }
+    ? readonly Key[]
+    : never,
+  listener: (
+    value: StoreValue<SomeStore>,
     changed: SomeStore extends {
       setKey: (key: infer Key, value: never) => unknown
     }

--- a/listen-keys/index.js
+++ b/listen-keys/index.js
@@ -6,6 +6,7 @@ export function listenKeys($store, keys, listener) {
     }
   })
 }
+
 export function subscribeKeys($store, keys, listener) {
   let unbind = listenKeys($store, keys, listener)
   listener($store.value)

--- a/listen-keys/index.js
+++ b/listen-keys/index.js
@@ -6,3 +6,8 @@ export function listenKeys($store, keys, listener) {
     }
   })
 }
+export function subscribeKeys($store, keys, listener) {
+  let unbind = listenKeys($store, keys, listener)
+  listener($store.value)
+  return unbind
+}

--- a/listen-keys/index.test.ts
+++ b/listen-keys/index.test.ts
@@ -1,7 +1,7 @@
 import { deepStrictEqual, equal } from 'node:assert'
 import { test } from 'node:test'
 
-import { deepMap, listenKeys, map } from '../index.js'
+import { deepMap, listenKeys, map, subscribeKeys } from '../index.js'
 
 test('listen for specific keys', () => {
   let events: string[] = []
@@ -54,4 +54,30 @@ test('allows setting specific deep keys', () => {
   $store.setKey('a.f[0][1]', { g: 0 })
   $store.setKey('a.f[0][0].g', 5)
   deepStrictEqual(events, ['e2', 'd[2]', 'd[1]4', 'g5'])
+})
+
+test('can subscribe to changes and call listener immediately', () => {
+  let events: string[] = []
+  let $store = map({ a: 1, b: 1 })
+
+  let unbind = subscribeKeys($store, ['a'], value => {
+    events.push(`${value.a} ${value.b}`)
+  })
+  deepStrictEqual(events, ['1 1'])
+
+  $store.setKey('b', 2)
+  deepStrictEqual(events, ['1 1'])
+
+  $store.setKey('a', 2)
+  deepStrictEqual(events, ['1 1', '2 2'])
+
+  $store.setKey('a', 3)
+  deepStrictEqual(events, ['1 1', '2 2', '3 2'])
+
+  $store.setKey('b', 3)
+  deepStrictEqual(events, ['1 1', '2 2', '3 2'])
+
+  unbind()
+  $store.setKey('a', 4)
+  deepStrictEqual(events, ['1 1', '2 2', '3 2'])
 })

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nanostores",
   "version": "0.10.0",
-  "description": "A tiny (286 bytes) state manager for React/Preact/Vue/Svelte with many atomic tree-shakable stores",
+  "description": "A tiny (287 bytes) state manager for React/Preact/Vue/Svelte with many atomic tree-shakable stores",
   "keywords": [
     "store",
     "state",
@@ -113,7 +113,7 @@
       "import": {
         "./index.js": "{ atom }"
       },
-      "limit": "286 B"
+      "limit": "287 B"
     },
     {
       "name": "Popular Set",


### PR DESCRIPTION
Adds a subscribeKeys function. It ensures there's a `subscribe` function for every `listen` function, aligning the API for all types of store listeners. Also updated the readme to describe the listenKeys function

Fixes #262