### PR TITLE
Add notify() store method to public types

### DIFF
--- a/atom/index.d.ts
+++ b/atom/index.d.ts
@@ -52,6 +52,14 @@ export interface ReadableAtom<Value = any> {
   ): () => void
 
   /**
+   * Low-level method to notify listeners about changes in the store.
+   *
+   * Can cause unexpected behaviour when combined with frontend frameworks
+   * that perform equality checks for values, such as React.
+   */
+  notify(oldValue: ReadonlyIfObject<Value>): void
+
+  /**
    * Unbind all listeners.
    */
   off(): void

--- a/deep-map/index.d.ts
+++ b/deep-map/index.d.ts
@@ -5,7 +5,7 @@ export { AllPaths, BaseDeepMap, FromPath, getPath, setPath } from './path.js'
 
 export type DeepMapStore<T extends BaseDeepMap> = Omit<
   WritableAtom<T>,
-  'listen' | 'setKey' | 'subscribe'
+  'listen' | 'notify' | 'setKey' | 'subscribe'
 > & {
   /**
    * Subscribe to store changes.
@@ -25,6 +25,14 @@ export type DeepMapStore<T extends BaseDeepMap> = Omit<
       changedKey: AllPaths<T> | undefined
     ) => void
   ): () => void
+
+  /**
+   * Low-level method to notify listeners about changes in the store.
+   *
+   * Can cause unexpected behaviour when combined with frontend frameworks
+   * doing equality checks for values, e.g. React.
+   */
+  notify(oldValue?: T, changedKey?: AllPaths<T>): void
 
   /**
    * Change key in store value.

--- a/map/index.d.ts
+++ b/map/index.d.ts
@@ -58,6 +58,14 @@ export interface MapStore<Value extends object = any>
   ): () => void
 
   /**
+   * Low-level method to notify listeners about changes in the store.
+   *
+   * Can cause unexpected behaviour when combined with frontend frameworks
+   * that perform equality checks for values, such as React.
+   */
+  notify(oldValue?: ReadonlyIfObject<Value>, changedKey?: AllKeys<Value>): void
+
+  /**
    * Change store value.
    *
    * ```js


### PR DESCRIPTION
Suggestion to re-add `notify()` to the public types following discussion in https://github.com/orgs/nanostores/discussions/276