### PR TITLE
fix: oldValue in atom notify optional

### DIFF
--- a/atom/index.d.ts
+++ b/atom/index.d.ts
@@ -57,7 +57,7 @@ export interface ReadableAtom<Value = any> {
    * Can cause unexpected behaviour when combined with frontend frameworks
    * that perform equality checks for values, such as React.
    */
-  notify(oldValue: ReadonlyIfObject<Value>): void
+  notify(oldValue?: ReadonlyIfObject<Value>): void
 
   /**
    * Unbind all listeners.


### PR DESCRIPTION
Noticed that I forgot to set the oldValue as optional in the atom notify method, only did it in the Map and DeepMap ones.