### PR TITLE
feat!: does not run queued listeners after they are unsubscribed

### DIFF
--- a/atom/index.js
+++ b/atom/index.js
@@ -18,9 +18,13 @@ export let atom = (initialValue, level) => {
 
       return () => {
         let index = listeners.indexOf(listener)
+        let queueIndex = listenerQueue.indexOf(listener)
         if (~index) {
           listeners.splice(index, 2)
           if (!--$atom.lc) $atom.off()
+        }
+        if (~queueIndex) {
+          listenerQueue.splice(index, 5)
         }
       }
     },

--- a/atom/index.test.ts
+++ b/atom/index.test.ts
@@ -262,20 +262,18 @@ test('supports conditional destroy', () => {
   deepStrictEqual(events, ['init', 'destroy', 'init'])
 })
 
-test('does not mutate listeners while change event', () => {
+test('does not run queued listeners after they are unsubscribed', () => {
   let events: string[] = []
-  let $store = atom<number | undefined>()
-
-  onMount($store, () => {
-    $store.set(0)
-  })
+  let $store = atom<number>(0)
 
   $store.listen(value => {
     events.push(`a${value}`)
-    unbindB()
     $store.listen(v => {
       events.push(`c${v}`)
     })
+    if (value > 1) {
+      unbindB()
+    }
   })
 
   let unbindB = $store.listen(value => {

--- a/computed/index.test.ts
+++ b/computed/index.test.ts
@@ -508,6 +508,27 @@ test('computed values update first', () => {
   deepStrictEqual(values, [1, 2, 'afterAtom', 2, 4, 'afterAtom'])
 })
 
+test('Unsubscribing from computed removes computed listeners from queue', () => {
+  let $atom = atom(0)
+  let $computed = computed($atom, value => value * 2)
+  let values: (number | string)[] = []
+
+  let unsubscribe = $computed.listen(() => {
+    values.push('afterAtom')
+  })
+  $atom.listen(value => {
+    values.push(value)
+    values.push($computed.get())
+    if (value > 1) {
+      unsubscribe()
+    }
+  })
+  $atom.set(1)
+  deepStrictEqual(values, [1, 2, 'afterAtom'])
+  $atom.set(2)
+  deepStrictEqual(values, [1, 2, 'afterAtom', 2, 4])
+})
+
 test('cleans up on unmount', async () => {
   let $source = atom({ count: 1 })
   let $derived = computed($source, s => s.count)

--- a/deep-map/index.test.ts
+++ b/deep-map/index.test.ts
@@ -299,16 +299,18 @@ test('deletes keys on undefined value', () => {
   deepStrictEqual(keys, [['a'], []])
 })
 
-test('does not mutate listeners while change event', () => {
+test('does not run queued listeners after they are unsubscribed', () => {
   let events: string[] = []
   let $store = deepMap<{ a: number }>({ a: 0 })
 
   $store.listen(value => {
     events.push(`a${value.a}`)
-    unbindB()
     $store.listen(v => {
       events.push(`c${v.a}`)
     })
+    if (value.a > 1) {
+      unbindB()
+    }
   })
 
   let unbindB = $store.listen(value => {

--- a/map/index.test.ts
+++ b/map/index.test.ts
@@ -299,16 +299,18 @@ test('deletes keys on undefined value', () => {
   deepStrictEqual(keys, [['a'], []])
 })
 
-test('does not mutate listeners while change event', () => {
+test('does not run queued listeners after they are unsubscribed', () => {
   let events: string[] = []
   let $store = map<{ a: number }>({ a: 0 })
 
   $store.listen(value => {
     events.push(`a${value.a}`)
-    unbindB()
     $store.listen(v => {
       events.push(`c${v.a}`)
     })
+    if (value.a > 1) {
+      unbindB()
+    }
   })
 
   let unbindB = $store.listen(value => {

--- a/package.json
+++ b/package.json
@@ -113,14 +113,14 @@
       "import": {
         "./index.js": "{ atom }"
       },
-      "limit": "287 B"
+      "limit": "303 B"
     },
     {
       "name": "Popular Set",
       "import": {
         "./index.js": "{ map, computed, }"
       },
-      "limit": "818 B"
+      "limit": "830 B"
     }
   ],
   "clean-publish": {


### PR DESCRIPTION
Changes the behaviour of unsubscribe to also remove listeners that have already been queued.

It's a breaking change.

I remade the tests "does not mutate listeners while change event". Can't really work out what it was testing, and if/how I should replace it with something else.