### PR TITLE
Add missing `Task` type in `batch` types 

### DIFF
--- a/computed/index.d.ts
+++ b/computed/index.d.ts
@@ -53,7 +53,7 @@ export const computed: Computed
 interface Batched {
   <Value extends any, OriginStore extends Store>(
     stores: OriginStore,
-    cb: (value: StoreValue<OriginStore>) => Value
+    cb: (value: StoreValue<OriginStore>) => Task<Value> | Value
   ): ReadableAtom<Value>
   /**
    * Create derived store, which use generates value from another stores.
@@ -71,7 +71,7 @@ interface Batched {
    */
   <Value extends any, OriginStores extends AnyStore[]>(
     stores: [...OriginStores],
-    cb: (...values: StoreValues<OriginStores>) => Value
+    cb: (...values: StoreValues<OriginStores>) => Task<Value> | Value
   ): ReadableAtom<Value>
 }
 


### PR DESCRIPTION
Allow to use `batched` with `task`.

Little example:
```ts
const someStore1 = atom('test');
const someStore2 = atom('test');

const batchedStore = batched([someStore1, someStore2], () => {
  return task(async () => {
    return 'task';
  });
});

batchedStore.subscribe(() => {});

setTimeout(() => {
  // Throws type error
  const value: string = batchedStore.get(); // Expected type 'string', got 'Task<string>'
});
```