### PR TITLE
fix(deepMap): incorrect previous value when listening deep store

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,18 @@ $profile.setKey('hobbies[0].friends[0].name', 'Leslie Knope')
 $profile.setKey('skills[0][0]', 'Whittling')
 ```
 
+Note that Deep Maps have a mutable state at the second level of nesting,
+and it uses [`structuredClone`] to get the previous value of the state
+for listeners such as `store.listen(cb)`, `store.subscribe(cb)`
+and `onNotify(store, cb)`.
+
+So, to get the correct previous value in the listener, you should use
+[transferable objects] in the store value.
+
+[`structuredClone`]: https://developer.mozilla.org/en-US/docs/Web/API/structuredClone#browser_compatibility
+[transferable objects]: https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Transferable_objects
+
+
 
 ### Lazy Stores
 

--- a/deep-map/index.js
+++ b/deep-map/index.js
@@ -6,7 +6,12 @@ export { getPath, setPath } from './path.js'
 export function deepMap(initial = {}) {
   let $deepMap = atom(initial)
   $deepMap.setKey = (key, value) => {
-    let oldValue = { ...$deepMap.value }
+    let oldValue
+    try {
+      oldValue = structuredClone($deepMap.value)
+    } catch {
+      oldValue = { ...$deepMap.value }
+    }
     if (getPath($deepMap.value, key) !== value) {
       $deepMap.value = { ...setPath($deepMap.value, key, value) }
       $deepMap.notify(oldValue, key)

--- a/deep-map/index.test.ts
+++ b/deep-map/index.test.ts
@@ -348,11 +348,9 @@ test('notifies correct previous value from deep store', t => {
     throw new Error('structuredClone is not supported')
   })
 
+  events = []
   $store.setKey('b.nested.deep', 3)
   deepStrictEqual(events, [
-    { a: 0, b: { nested: { deep: 0 } } },
-    { a: 1, b: { nested: { deep: 0 } } },
-    { a: 1, b: { nested: { deep: 1 } } },
     { a: 1, b: { nested: { deep: 3 } } }
   ])
 

--- a/deep-map/index.test.ts
+++ b/deep-map/index.test.ts
@@ -322,24 +322,41 @@ test('does not mutate listeners while change event', () => {
   deepStrictEqual(events, ['a1', 'b1', 'a2', 'c2'])
 })
 
-test('notifies correct previous value from deep store', () => {
-  type DeepValue = { a: number; b: { nested: number } }
+test('notifies correct previous value from deep store', t => {
+  type DeepValue = { a: number; b: { nested: { deep: number } } }
 
   let events: DeepValue[] = []
-  let $store = deepMap<DeepValue>({ a: 0, b: { nested: 0 } })
+  let $store = deepMap<DeepValue>({
+    a: 0,
+    b: { nested: { deep: 0 } }
+  })
 
   let unbind = onNotify($store, ({ oldValue }) => {
     events.push(oldValue)
   })
 
   $store.setKey('a', 1)
-  $store.setKey('b.nested', 1)
-  $store.setKey('b.nested', 2)
+  $store.setKey('b.nested.deep', 1)
+  $store.setKey('b.nested.deep', 2)
   deepStrictEqual(events, [
-    { a: 0, b: { nested: 0 } },
-    { a: 1, b: { nested: 0 } },
-    { a: 1, b: { nested: 1 } }
+    { a: 0, b: { nested: { deep: 0 } } },
+    { a: 1, b: { nested: { deep: 0 } } },
+    { a: 1, b: { nested: { deep: 1 } } }
   ])
+
+  t.mock.method(global, 'structuredClone', () => {
+    throw new Error('structuredClone is not supported')
+  })
+
+  $store.setKey('b.nested.deep', 3)
+  deepStrictEqual(events, [
+    { a: 0, b: { nested: { deep: 0 } } },
+    { a: 1, b: { nested: { deep: 0 } } },
+    { a: 1, b: { nested: { deep: 1 } } },
+    { a: 1, b: { nested: { deep: 3 } } }
+  ])
+
+  t.mock.reset()
   unbind()
 })
 


### PR DESCRIPTION
To use `structuredClone` as part of the core, we would have to rewrite `notify`, which would add about 20 bytes to the `atom`, just to support `deepMap` mutability.

I think until we make `notify` a public API, it's better to use `structuredClone` only inside `deepMap`.