### PR TITLE
Add `batch` function for batching writes

### DIFF
--- a/atom/index.d.ts
+++ b/atom/index.d.ts
@@ -137,3 +137,5 @@ export declare let notifyId: number
 export function atom<Value, StoreExt = {}>(
   ...args: undefined extends Value ? [] | [Value] : [Value]
 ): StoreExt & WritableAtom<Value>
+
+export function batch<T>(cb: () => T): T

--- a/package.json
+++ b/package.json
@@ -92,14 +92,14 @@
       "import": {
         "./index.js": "{ atom }"
       },
-      "limit": "286 B"
+      "limit": "308 B"
     },
     {
       "name": "Popular Set",
       "import": {
         "./index.js": "{ map, computed, }"
       },
-      "limit": "818 B"
+      "limit": "836 B"
     }
   ],
   "clean-publish": {


### PR DESCRIPTION
The existing `batched` function has a few problems:
- It runs callbacks using setTimeout, which is less efficient and can occasionally be problematic if you're expecting events to fire in a certain order.
- It requires the consumer of the state to opt in to using it at each call site. This requires extra mental overhead and is susceptible to mistakes (forgetting to use `batched` instead of `computed`).
- Even if you always use `batched`, it still allows invalid/stale intermediate values to be observed via `subscribe`. For example, if I want to log both `$foo` and `$bar`, but only when `$foo` changes (not when `$bar` changes), my subscription to `$foo` could see the invalid/stale intermediate value of `$bar` when they change at the same time. To fix this, I'd have to do a setTimeout hack in my callback like `batched` does.
- If I'm creating a library that exposes a bunch of atoms, I want to be able to batch the library's writes to those atoms so the users of my library don't have to think about any of the above.

For the reasons above, all state management libraries I know of that do manual batching do it on event production rather than event consumption. Examples:
- https://docs.solidjs.com/reference/reactive-utilities/batch#batch
- https://github.com/preactjs/signals/#batchfn
- https://mobx.js.org/api.html#transaction
- https://github.com/AmadeusITGroup/tansu/#batch
- https://www.reatom.dev/package/core#batch

This PR brings that same ability to nanostores with a new `batch` function. For all writes that happen inside the batch callback, notifications won't be sent until the callback completes. Example:

```ts
const $sortBy = atom('id')
const $categoryId = atom('')

export function resetFilters () {
  batch(() => {
    $sortBy.set('date')
    $categoryId.set('1')
  })
}
```

If you batch your writes using `batch`, `batched` is no longer necessary, so it might make sense to deprecate `batched` and encourage `batch` instead. Let me know what you think, I can update the PR with docs.

The implementation is simple and minimal because there was already a `listenerQueue` that was doing implicit batching for writes happening inside listener callbacks. This only adds 22 bytes to the min bundle size and 18 bytes to the max size. If `batched` eventually gets removed, it will probably be a net reduction in bytes.
