### PR TITLE
Fix stale computed values

### DIFF
--- a/atom/index.js
+++ b/atom/index.js
@@ -1,6 +1,7 @@
 import { clean } from '../clean-stores/index.js'
 
 let listenerQueue = []
+export let epoch = 0
 
 export let atom = (initialValue) => {
   let listeners = []
@@ -24,6 +25,7 @@ export let atom = (initialValue) => {
       }
     },
     notify(oldValue, changedKey) {
+      epoch++
       let runListenerQueue = !listenerQueue.length
       for (let listener of listeners) {
         listenerQueue.push(

--- a/computed/index.js
+++ b/computed/index.js
@@ -27,7 +27,7 @@ let computedStore = (stores, cb, batched) => {
       }
     }
   }
-  let $computed = atom(undefined, Math.max(...stores.map($s => $s.l)) + 1)
+  let $computed = atom(undefined)
   let get = $computed.get
   $computed.get = () => {
     set()
@@ -43,7 +43,7 @@ let computedStore = (stores, cb, batched) => {
     : set
 
   onMount($computed, () => {
-    let unbinds = stores.map($store => $store.listen(run, -1 / $computed.l))
+    let unbinds = stores.map($store => $store.listen(run))
     set()
     return () => {
       for (let unbind of unbinds) unbind()

--- a/computed/index.js
+++ b/computed/index.js
@@ -28,6 +28,11 @@ let computedStore = (stores, cb, batched) => {
     }
   }
   let $computed = atom(undefined, Math.max(...stores.map($s => $s.l)) + 1)
+  let get = $computed.get
+  $computed.get = () => {
+    set()
+    return get()
+  }
 
   let timer
   let run = batched

--- a/computed/index.js
+++ b/computed/index.js
@@ -1,4 +1,4 @@
-import { atom } from '../atom/index.js'
+import { atom, epoch } from '../atom/index.js'
 import { onMount } from '../lifecycle/index.js'
 
 let computedStore = (stores, cb, batched) => {
@@ -6,7 +6,10 @@ let computedStore = (stores, cb, batched) => {
 
   let previousArgs
   let currentRunId = 0
+  let currentEpoch
   let set = () => {
+    if (currentEpoch === epoch) return
+    currentEpoch = epoch
     let args = stores.map($store => $store.get())
     if (
       previousArgs === undefined ||

--- a/computed/index.test.ts
+++ b/computed/index.test.ts
@@ -526,3 +526,42 @@ test('cleans up on unmount', async () => {
   equal($derived.lc, 0)
   equal($source.lc, 0)
 })
+
+test('stale computed in other computed', () => {
+  let $atom = atom(1)
+  let values: (number | string)[] = []
+  let $computed1 = computed($atom, () => {values.push($computed2.get())})
+  let $computed2 = computed($atom, value => value * 2)
+  $computed1.subscribe(() => {})
+  $atom.set(2)
+  deepStrictEqual(values, [2, 4])
+})
+
+test('stale computed in listener', () => {
+  let $event = atom()
+  let $atom = atom(1)
+  let $computed = computed($atom, value => value * 2)
+  $computed.listen(() => {})
+  let values: (number | string)[] = []
+  $event.listen(() => {
+    $atom.set(2)
+    values.push($computed.get())
+  })
+  $event.set("foo")
+  deepStrictEqual(values, [4])
+})
+
+test('stale computed via nested dependency', () => {
+  let $event = atom()
+  let $atom = atom(1)
+  let $computed1 = computed($atom, value => value * 2)
+  let $computed2 = computed($computed1, value => value * 3)
+  $computed2.listen(() => {})
+  let values: (number | string)[] = []
+  $event.listen(() => {
+    $atom.set(2)
+    values.push($computed2.get())
+  })
+  $event.set("foo")
+  deepStrictEqual(values, [12])
+})

--- a/package.json
+++ b/package.json
@@ -92,14 +92,14 @@
       "import": {
         "./index.js": "{ atom }"
       },
-      "limit": "286 B"
+      "limit": "235 B"
     },
     {
       "name": "Popular Set",
       "import": {
         "./index.js": "{ map, computed, }"
       },
-      "limit": "833 B"
+      "limit": "769 B"
     }
   ],
   "clean-publish": {

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
       "import": {
         "./index.js": "{ map, computed, }"
       },
-      "limit": "818 B"
+      "limit": "833 B"
     }
   ],
   "clean-publish": {


### PR DESCRIPTION
Fixes #299

This fixes stale values in computed stores by checking if dependencies have changed any time `get()` is called. It does have a perf impact, though I added an `epoch` optimization to help with that. And correctness should take precedence over performance (no other state library I'm aware of has this stale value problem). The benefits are:

- computed stores never return stale values
- this also solves the diamond problem, so the previous logic that was added for that is no longer needed, which means:
  - simpler logic
  - no need to store and compute a level (`l`) for each atom
  - bundle size reduced (min: 286B to 235B, max:  818B to 769B)
  - better perf in certain areas -- processing the `listenerQueue` is now O(n) instead of O(n^2)

Another potential benefit -- this change means that when calling `get()` on an atom with 0 subscribers, we no longer have to [add a dummy subscriber](https://github.com/nanostores/nanostores/blob/7fb5cd871fa00f484ebc866fdf330b56cab2aa20/atom/index.js#L9-L11). I'm holding off on making that change, because it would be a breaking change -- some code could be relying on the side effect of `onMount` firing. But it could be considered for a future major version -- IMO it would be cleaner. Right now, if you call `get()` on a computed store, it will never unsubscribe, and the value will be needlessly recomputed when the dependencies change, even if the only listener is the dummy listener.
