### PR TITLE
Fix issues with removing listeners from the queue

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,14 +92,14 @@
       "import": {
         "./index.js": "{ atom }"
       },
-      "limit": "250 B"
+      "limit": "265 B"
     },
     {
       "name": "Popular Set",
       "import": {
         "./index.js": "{ map, computed, }"
       },
-      "limit": "786 B"
+      "limit": "806 B"
     }
   ],
   "clean-publish": {


### PR DESCRIPTION
After switching to the `next` branch I discovered several issues introduced by #280:

- It was passing `index` instead of `queueIndex` to `listenerQueue.splice`. In addition to being the wrong index, this can put `listenerQueue` into a really weird/bad state when `index` is not divisible by 4 (since `listenerQueue` uses chunks of 4 items per listener).
- It was only removing the first listener it found in the queue, so it wouldn't work properly if the same listener was in the queue multiple times (e.g., when calling `set` on the same store multiple times inside a listener)
- It was removing items from the front of the queue, even if those items had already been processed. This would cause the next iteration of the queue processing loop to skip unprocessed items (because everything in the array gets shifted when calling `splice`)
- It was searching all items of `listenerQueue` for `listener`, but as mentioned above, only every 4th item is a valid position to search in. This meant that if a listener function was set as the value of a store, it would be incorrectly found as a listener, and `listenerQueue` would end up in a bad state. This is an unlikely scenario to happen in the real world, but easy enough to fix.

I added tests for all of those and fixed the issues.

cc @gismya 