### PR TITLE
Improve computed perf by setting currentEpoch after set

### DIFF
--- a/computed/index.js
+++ b/computed/index.js
@@ -27,6 +27,7 @@ let computedStore = (stores, cb, batched) => {
         })
       } else {
         $computed.set(value)
+        currentEpoch = epoch
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
       "import": {
         "./index.js": "{ map, computed, }"
       },
-      "limit": "806 B"
+      "limit": "814 B"
     }
   ],
   "clean-publish": {


### PR DESCRIPTION
The benchmark for `computed` on my machine increased from 3,815 ops/sec to 5,193 ops/sec