### PR TITLE
Add `batch` function for batching writes

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A tiny state manager for **React**, **React Native**, **Preact**, **Vue**,
 **Svelte**, **Solid**, **Lit**, **Angular**, and vanilla JS.
 It uses **many atomic stores** and direct manipulation.
 
-* **Small.** Between 286 and 818 bytes (minified and brotlied).
+* **Small.** Between 287 and 818 bytes (minified and brotlied).
   Zero dependencies. It uses [Size Limit] to control size.
 * **Fast.** With small atomic and derived stores, you do not need to call
   the selector function for all components on every store change.
@@ -163,9 +163,9 @@ const unbindListener = $counter.subscribe((value, oldValue) => {
 ```
 
 `store.subscribe(cb)` in contrast with `store.listen(cb)` also call listeners
-immediately during the subscription. Note that the initial call for `store.
-subscribe(cb)` will not have any previous value and `oldValue`
-will be `undefined`.
+immediately during the subscription.
+Note that the initial call for `store.subscribe(cb)` will not have any
+previous value and `oldValue` will be `undefined`.
 
 [router]: https://github.com/nanostores/router
 
@@ -217,6 +217,20 @@ $profile.listen((profile, oldProfile, changed) => {
   console.log(`${changed} new value ${profile[changed]}`)
 })
 ```
+
+You can also listen for specific keys of the store being changed, using
+`listenKeys` and `subscribeKeys`.
+
+```ts
+listenKeys($profile, ['name'], (value, oldValue, changed) => {
+  console.log(`$profile.Name new value ${value.name}`)
+})
+```
+
+`subscribeKeys(store, keys, cb)` in contrast with `listenKeys(store, keys, cb)`
+also call listeners immediately during the subscription.
+Please note that when using subscribe for store changes, the initial evaluation
+of the callback has undefined old value and changed key.
 
 
 ### Deep Maps

--- a/README.md
+++ b/README.md
@@ -210,10 +210,12 @@ Setting `undefined` will remove optional key:
 $profile.setKey('email', undefined)
 ```
 
-A store’s listeners will receive a third argument `changedKey` when the store is
-updated using `setKey`. However, if the store is updated using `set`,
-`changedKey` will be `undefined`. So, it's best not to rely on `changedKey` to
-detect if a key has changed.
+Deprecated: a store’s listeners will receive a third argument `changedKey` when
+the store is updated using `setKey`. However, if the store is updated using
+`set`, `changedKey` will be `undefined`. And if the store is updated multiple
+times inside a batch, `changedKey` will only contain the value from the first
+update during the batch. So, it's best not to rely on `changedKey` to detect if
+a key has changed.
 
 `listenKeys` is a better way to listen for specific keys of the store being
 changed. The callback will fire whenever the specified keys are changed
@@ -333,7 +335,7 @@ it('is anonymous from the beginning', () => {
 
 ### Computed Stores
 
-Computed store is based on other store’s value.
+Computed store is based on other stores' values.
 
 ```ts
 import { computed } from 'nanostores'
@@ -342,6 +344,17 @@ import { $users } from './users.js'
 export const $admins = computed($users, users => {
   // This callback will be called on every `users` changes
   return users.filter(user => user.isAdmin)
+})
+```
+
+It can be calculated from multiple stores:
+
+```ts
+import { $lastVisit } from './lastVisit.js'
+import { $posts } from './posts.js'
+
+export const $newPosts = computed([$lastVisit, $posts], (lastVisit, posts) => {
+  return posts.filter(post => post.publishedAt > lastVisit)
 })
 ```
 
@@ -358,10 +371,55 @@ export const $user = computed($userId, userId => task(async () => {
 }))
 ```
 
-By default, `computed` stores update _each_ time any of their dependencies
-gets updated. If you are fine with waiting until the end of a tick, you can
-use `batched`. The only difference with `computed` is that it will wait until
-the end of a tick to update itself.
+### Batching
+By default, listeners run immediately when a store's value is changed. If you
+are changing multiple stores together, you can use `batch` to delay the
+listeners from running until the end of the batch callback. That way, if a
+store's value changes multiple times, or multiple dependencies of a `computed`
+change, their listeners will only be called once at the end of the batch.
+
+```ts
+import { batch } from 'nanostores'
+
+const $sortBy = atom('id')
+const $categoryId = atom('')
+
+export const $link = computed([$sortBy, $categoryId], (sortBy, categoryId) => {
+  return `/api/entities?sortBy=${sortBy}&categoryId=${categoryId}`
+})
+
+// $link will only update once even though you changed its dependencies twice
+export function resetFilters () {
+  batch(() => {
+    $sortBy.set('date')
+    $categoryIdFilter.set('1')
+  })
+}
+```
+
+Listener callbacks are automatically batched.
+
+```ts
+const $atom1 = atom(0)
+const $atom2 = atom(0)
+$atom2.listen((value) => {
+  console.log(value)
+})
+$atom1.subscribe(() => {
+  // This callback is automatically batched, no need to use `batch`.
+  // The listener for $atom2 will only be called once at the end of this callback.
+  $atom2.set(1)
+  doStuff()
+  $atom2.set(2)
+})
+```
+
+Sometimes you want to ensure that a computed store's updates are batched even
+if dependencies are updated outside of a `batch` callback (e.g., in a library
+where you don't control how dependencies are updated). In that case, you can
+define your computed store using `batched` instead of `computed`. This will
+cause the store to wait until the end of the next event loop tick before
+recomputing the value.
 
 ```ts
 import { batched } from 'nanostores'
@@ -373,24 +431,12 @@ export const $link = batched([$sortBy, $categoryId], (sortBy, categoryId) => {
   return `/api/entities?sortBy=${sortBy}&categoryId=${categoryId}`
 })
 
-// `batched` will update only once even you changed two stores
+// $link will update only once even though you changed its dependencies twice
 export function resetFilters () {
   $sortBy.set('date')
   $categoryIdFilter.set('1')
 }
 ```
-
-Both `computed` and `batched` can be calculated from multiple stores:
-
-```ts
-import { $lastVisit } from './lastVisit.js'
-import { $posts } from './posts.js'
-
-export const $newPosts = computed([$lastVisit, $posts], (lastVisit, posts) => {
-  return posts.filter(post => post.publishedAt > lastVisit)
-})
-```
-
 
 ### Tasks
 

--- a/README.md
+++ b/README.md
@@ -210,20 +210,18 @@ Setting `undefined` will remove optional key:
 $profile.setKey('email', undefined)
 ```
 
-Store’s listeners will receive third argument with changed key.
+A store’s listeners will receive a third argument `changedKey` when the store is
+updated using `setKey`. However, if the store is updated using `set`,
+`changedKey` will be `undefined`. So, it's best not to rely on `changedKey` to
+detect if a key has changed.
+
+`listenKeys` is a better way to listen for specific keys of the store being
+changed. The callback will fire whenever the specified keys are changed
+(regardless of whether they were updated using `setKey` or `set`).
 
 ```ts
-$profile.listen((profile, oldProfile, changed) => {
-  console.log(`${changed} new value ${profile[changed]}`)
-})
-```
-
-You can also listen for specific keys of the store being changed, using
-`listenKeys` and `subscribeKeys`.
-
-```ts
-listenKeys($profile, ['name'], (value, oldValue, changed) => {
-  console.log(`$profile.Name new value ${value.name}`)
+listenKeys($profile, ['name'], (value, oldValue) => {
+  console.log(`$profile.name new value ${value.name}`)
 })
 ```
 
@@ -232,6 +230,10 @@ also call listeners immediately during the subscription.
 Please note that when using subscribe for store changes, the initial evaluation
 of the callback has undefined old value and changed key.
 
+If you want to listen to keys beyond the top level, you can use
+`listenKeyPaths` and `subscribeKeyPaths`. These work just like `listenKeys` and
+`subscribeKeys`, but they take a key *path* (like `foo[0].bar`, as used in
+`deepMap`).
 
 ### Deep Maps
 

--- a/atom/index.d.ts
+++ b/atom/index.d.ts
@@ -52,6 +52,14 @@ export interface ReadableAtom<Value = any> {
   ): () => void
 
   /**
+   * Low-level method to notify listeners about changes in the store.
+   *
+   * Can cause unexpected behaviour when combined with frontend frameworks
+   * that perform equality checks for values, such as React.
+   */
+  notify(oldValue: ReadonlyIfObject<Value>): void
+
+  /**
    * Unbind all listeners.
    */
   off(): void

--- a/atom/index.d.ts
+++ b/atom/index.d.ts
@@ -57,7 +57,7 @@ export interface ReadableAtom<Value = any> {
    * Can cause unexpected behaviour when combined with frontend frameworks
    * that perform equality checks for values, such as React.
    */
-  notify(oldValue: ReadonlyIfObject<Value>): void
+  notify(oldValue?: ReadonlyIfObject<Value>): void
 
   /**
    * Unbind all listeners.

--- a/atom/index.d.ts
+++ b/atom/index.d.ts
@@ -52,14 +52,6 @@ export interface ReadableAtom<Value = any> {
   ): () => void
 
   /**
-   * Low-level method to notify listeners about changes in the store.
-   *
-   * Can cause unexpected behaviour when combined with frontend frameworks
-   * that perform equality checks for values, such as React.
-   */
-  notify(oldValue?: ReadonlyIfObject<Value>): void
-
-  /**
    * Unbind all listeners.
    */
   off(): void

--- a/atom/index.d.ts
+++ b/atom/index.d.ts
@@ -145,3 +145,5 @@ export declare let notifyId: number
 export function atom<Value, StoreExt = {}>(
   ...args: undefined extends Value ? [] | [Value] : [Value]
 ): StoreExt & WritableAtom<Value>
+
+export function batch<T>(cb: () => T): T

--- a/atom/index.d.ts
+++ b/atom/index.d.ts
@@ -31,6 +31,25 @@ export interface ReadableAtom<Value = any> {
   get(): Value
 
   /**
+   * This method is used for determining when notifications should be skipped
+   * (when a new value is equal to the old one). By default it is set to
+   * `Object.is`, but you can override it for custom behavior.
+   *
+   * ```
+   * $atom = atom()
+   * $atom.isEqual = () => false
+   * $atom.set(1)
+   * // Listeners will be notified even though the value is the same
+   * $atom.set(1)
+   * ```
+   *
+   * @param value1 First value to compare
+   * @param value2 Second value to compare
+   * @returns Whether the values should be treated as equal for notifications
+   */
+  isEqual(value1: unknown, value2: unknown): boolean
+
+  /**
    * Listeners count.
    */
   readonly lc: number

--- a/atom/index.js
+++ b/atom/index.js
@@ -18,9 +18,13 @@ export let atom = (initialValue, level) => {
 
       return () => {
         let index = listeners.indexOf(listener)
+        let queueIndex = listenerQueue.indexOf(listener)
         if (~index) {
           listeners.splice(index, 2)
           if (!--$atom.lc) $atom.off()
+        }
+        if (~queueIndex) {
+          listenerQueue.splice(index, 5)
         }
       }
     },

--- a/atom/index.js
+++ b/atom/index.js
@@ -63,7 +63,7 @@ export let atom = (initialValue) => {
         }
       }
     },
-    notify(oldValue, changedKey) {
+    notify(changedKey) {
       epoch++
       let queueWasEmpty = !listenerQueue.length
       for (let listener of listeners) {
@@ -81,7 +81,7 @@ export let atom = (initialValue) => {
       let oldValue = $atom.value
       if (oldValue !== newValue) {
         $atom.value = newValue
-        $atom.notify(oldValue)
+        $atom.notify()
       }
     },
     subscribe(listener) {

--- a/atom/index.js
+++ b/atom/index.js
@@ -24,7 +24,7 @@ export let atom = (initialValue) => {
           if (!--$atom.lc) $atom.off()
         }
         if (~queueIndex) {
-          listenerQueue.splice(index, 5)
+          listenerQueue.splice(index, 4)
         }
       }
     },

--- a/atom/index.js
+++ b/atom/index.js
@@ -34,11 +34,12 @@ export let atom = (initialValue) => {
       }
       return $atom.value
     },
+    isEqual: Object.is,
     lc: 0,
     listen(_listener) {
       let listener = (changedKey) => {
         let value = $atom.get()
-        if (value === oldValue) return
+        if ($atom.isEqual(oldValue, value)) return
         let currentOldValue = oldValue
         oldValue = value
         _listener(value, currentOldValue, changedKey)
@@ -78,8 +79,7 @@ export let atom = (initialValue) => {
        We will redefine it in onMount and onStop. */
     off() {},
     set(newValue) {
-      let oldValue = $atom.value
-      if (oldValue !== newValue) {
+      if (!$atom.isEqual($atom.value, newValue)) {
         $atom.value = newValue
         $atom.notify()
       }

--- a/atom/index.test.ts
+++ b/atom/index.test.ts
@@ -262,20 +262,18 @@ test('supports conditional destroy', () => {
   deepStrictEqual(events, ['init', 'destroy', 'init'])
 })
 
-test('does not mutate listeners while change event', () => {
+test('does not run queued listeners after they are unsubscribed', () => {
   let events: string[] = []
-  let $store = atom<number | undefined>()
-
-  onMount($store, () => {
-    $store.set(0)
-  })
+  let $store = atom<number>(0)
 
   $store.listen(value => {
     events.push(`a${value}`)
-    unbindB()
     $store.listen(v => {
       events.push(`c${v}`)
     })
+    if (value > 1) {
+      unbindB()
+    }
   })
 
   let unbindB = $store.listen(value => {

--- a/atom/index.test.ts
+++ b/atom/index.test.ts
@@ -399,6 +399,69 @@ test('prevents notifying when new value is referentially equal to old one', () =
   clock.runAll()
 })
 
+test('custom isEqual: notifies when returning false, even when values are the same', () => {
+  let events: (string | undefined)[] = []
+  let $store = atom('old')
+  $store.isEqual = () => false
+
+  let unbind = $store.subscribe(value => {
+    events.push(value)
+  })
+  deepStrictEqual(events, ['old'])
+
+  $store.set('old')
+  deepStrictEqual(events, ['old', 'old'])
+
+  $store.set('new')
+  deepStrictEqual(events, ['old', 'old', 'new'])
+
+  unbind()
+  clock.runAll()
+})
+
+test('custom isEqual: does not notify when returning true, even when values are different', () => {
+  let events: (string | undefined)[] = []
+  let $store = atom('old')
+  $store.isEqual = () => true
+
+  let unbind = $store.subscribe(value => {
+    events.push(value)
+  })
+  deepStrictEqual(events, ['old'])
+
+  $store.set('new')
+  deepStrictEqual(events, ['old'])
+
+  unbind()
+  clock.runAll()
+})
+
+// This test fails when using === to compare instead of Object.is
+test('listener is not called when value is set to NaN a second time', () => {
+  let events = ""
+  let $store = atom(NaN)
+  let unbind = $store.subscribe(value => {
+    events += value + " "
+  })
+  $store.set(NaN)
+  deepStrictEqual(events, "NaN ")
+  unbind()
+  clock.runAll()
+})
+
+// This test fails when using === to compare instead of Object.is
+test('listener is called when value changes from -0 to +0', () => {
+  let events: number[] = []
+  let $store = atom(-0)
+  let unbind = $store.subscribe(value => {
+    events.push(value)
+  })
+  $store.set(+0)
+  deepStrictEqual(events, [-0, +0])
+  unbind()
+  clock.runAll()
+})
+
 test('can use previous value in listeners', () => {
   let events: (number | undefined)[] = []
   let $store = atom(0)

--- a/atom/index.test.ts
+++ b/atom/index.test.ts
@@ -2,7 +2,8 @@ import FakeTimers from '@sinonjs/fake-timers'
 import { deepStrictEqual, equal } from 'node:assert'
 import { test } from 'node:test'
 
-import { atom, onMount } from '../index.js'
+import { atom, computed, onMount } from '../index.js'
+import { batch } from './index.js'
 
 let clock = FakeTimers.install()
 
@@ -422,5 +423,92 @@ test('can use previous value in subscribers', () => {
   $store.set(2)
   deepStrictEqual(events, [undefined, 0, 1])
   unbind()
+  clock.runAll()
+})
+
+test('without batch', () => {
+  let events = ""
+  let $a = atom("a1")
+  let $b = atom("b1")
+  let unbind = $a.subscribe(() => {
+    events += $a.get() + $b.get() + " "
+  })
+  $a.set("a2")
+  $b.set("b2")
+  equal(events, 'a1b1 a2b1 ')
+  unbind()
+  clock.runAll()
+})
+
+test('batch', () => {
+  let events = ""
+  let $a = atom("a1")
+  let $b = atom("b1")
+  let unbind = $a.subscribe(() => {
+    events += $a.get() + $b.get() + " "
+  })
+  batch(() => {
+    $a.set("a2")
+    $b.set("b2")
+  })
+
+  equal(events, 'a1b1 a2b2 ')
+  unbind()
+  clock.runAll()
+})
+
+test('nested batch', () => {
+  let events = ""
+  let $a = atom("a1")
+  let $b = atom("b1")
+  let unbind = $a.subscribe(() => {
+    events += $a.get() + $b.get() + " "
+  })
+  batch(() => {
+    $a.set("a2")
+    batch(() => {
+      $b.set("b2")
+    })
+  })
+
+  equal(events, 'a1b1 a2b2 ')
+  unbind()
+  clock.runAll()
+})
+
+test('batch started from listener', () => {
+  let events = ""
+  let $a = atom("a1")
+  let $b = atom("b1")
+  let unbind = $a.subscribe(() => {
+    events += $a.get() + $b.get() + " "
+  })
+  let $c = atom()
+  $c.listen(() => {
+    batch(() => {
+      $a.set("a2")
+      $b.set("b2")
+    })
+  })
+  $c.set("foo")
+
+  equal(events, 'a1b1 a2b2 ')
+  unbind()
+  clock.runAll()
+})
+
+test('batch with computed', () => {
+  let events = ""
+  let $a = atom("a1")
+  let $b = atom("b1")
+  let $c = computed([$a, $b], (a, b) => {
+    events += a + b + " "
+  })
+  $c.get()
+  batch(() => {
+    $a.set("a2")
+    $b.set("b2")
+  })
+  equal(events, 'a1b1 a2b2 ')
   clock.runAll()
 })

--- a/computed/index.js
+++ b/computed/index.js
@@ -1,4 +1,4 @@
-import { atom } from '../atom/index.js'
+import { atom, epoch } from '../atom/index.js'
 import { onMount } from '../lifecycle/index.js'
 
 let computedStore = (stores, cb, batched) => {
@@ -6,7 +6,10 @@ let computedStore = (stores, cb, batched) => {
 
   let previousArgs
   let currentRunId = 0
+  let currentEpoch
   let set = () => {
+    if (currentEpoch === epoch) return
+    currentEpoch = epoch
     let args = stores.map($store => $store.get())
     if (
       previousArgs === undefined ||
@@ -27,7 +30,12 @@ let computedStore = (stores, cb, batched) => {
       }
     }
   }
-  let $computed = atom(undefined, Math.max(...stores.map($s => $s.l)) + 1)
+  let $computed = atom(undefined)
+  let get = $computed.get
+  $computed.get = () => {
+    set()
+    return get()
+  }
 
   let timer
   let run = batched
@@ -38,7 +46,7 @@ let computedStore = (stores, cb, batched) => {
     : set
 
   onMount($computed, () => {
-    let unbinds = stores.map($store => $store.listen(run, -1 / $computed.l))
+    let unbinds = stores.map($store => $store.listen(run))
     set()
     return () => {
       for (let unbind of unbinds) unbind()

--- a/computed/index.js
+++ b/computed/index.js
@@ -27,6 +27,7 @@ let computedStore = (stores, cb, batched) => {
         })
       } else {
         $computed.set(value)
+        currentEpoch = epoch
       }
     }
   }

--- a/computed/index.js
+++ b/computed/index.js
@@ -48,6 +48,8 @@ let computedStore = (stores, cb, batched) => {
 
   onMount($computed, () => {
     let unbinds = stores.map($store => $store.listen(run))
+    // Set the initial value before the first listener gets added so the call
+    // to get() inside listen() doesn't immediately call the listener.
     set()
     return () => {
       for (let unbind of unbinds) unbind()

--- a/computed/index.test.ts
+++ b/computed/index.test.ts
@@ -508,6 +508,27 @@ test('computed values update first', () => {
   deepStrictEqual(values, [1, 2, 'afterAtom', 2, 4, 'afterAtom'])
 })
 
+test('Unsubscribing from computed removes computed listeners from queue', () => {
+  let $atom = atom(0)
+  let $computed = computed($atom, value => value * 2)
+  let values: (number | string)[] = []
+
+  let unsubscribe = $computed.listen(() => {
+    values.push('afterAtom')
+  })
+  $atom.listen(value => {
+    values.push(value)
+    values.push($computed.get())
+    if (value > 1) {
+      unsubscribe()
+    }
+  })
+  $atom.set(1)
+  deepStrictEqual(values, [1, 2, 'afterAtom'])
+  $atom.set(2)
+  deepStrictEqual(values, [1, 2, 'afterAtom', 2, 4])
+})
+
 test('cleans up on unmount', async () => {
   let $source = atom({ count: 1 })
   let $derived = computed($source, s => s.count)

--- a/deep-map/index.d.ts
+++ b/deep-map/index.d.ts
@@ -32,7 +32,9 @@ export type DeepMapStore<T extends BaseDeepMap> = {
   notify(oldValue?: T, changedKey?: AllPaths<T>): void
 
   /**
-   * Change key in store value.
+   * Change key in store value. Copies are made at each level of `key` so that
+   * the old value is not mutated (but it does not do a full deep copy --
+   * references to objects will still be shared between the old and new value).
    *
    * ```js
    * $settings.setKey('visuals.theme', 'dark')

--- a/deep-map/index.d.ts
+++ b/deep-map/index.d.ts
@@ -24,6 +24,14 @@ export type DeepMapStore<T extends BaseDeepMap> = {
   ): () => void
 
   /**
+   * Low-level method to notify listeners about changes in the store.
+   *
+   * Can cause unexpected behaviour when combined with frontend frameworks
+   * doing equality checks for values, e.g. React.
+   */
+  notify(oldValue?: T, changedKey?: AllPaths<T>): void
+
+  /**
    * Change key in store value.
    *
    * ```js
@@ -58,10 +66,7 @@ export type DeepMapStore<T extends BaseDeepMap> = {
       changedKey: AllPaths<T> | undefined
     ) => void
   ): () => void
-} & Omit<
-  WritableAtom<T>,
-  'listen' | 'setKey' | 'subscribe'
->
+} & Omit<WritableAtom<T>, 'listen' | 'notify' | 'setKey' | 'subscribe'>
 
 /**
  * Create deep map store. Deep map store is a store with an object as store

--- a/deep-map/index.d.ts
+++ b/deep-map/index.d.ts
@@ -1,7 +1,7 @@
 import type { WritableAtom } from '../atom/index.js'
 import type { AllPaths, BaseDeepMap, FromPath } from './path.js'
 
-export { AllPaths, BaseDeepMap, FromPath, getPath, setPath } from './path.js'
+export { AllPaths, BaseDeepMap, FromPath, getPath, setByKey, setPath } from './path.js'
 
 export type DeepMapStore<T extends BaseDeepMap> = {
   /**

--- a/deep-map/index.js
+++ b/deep-map/index.js
@@ -7,9 +7,8 @@ export function deepMap(initial = {}) {
   let $deepMap = atom(initial)
   $deepMap.setKey = (key, value) => {
     if (getPath($deepMap.value, key) !== value) {
-      let oldValue = $deepMap.value
       $deepMap.value = setPath($deepMap.value, key, value)
-      $deepMap.notify(oldValue, key)
+      $deepMap.notify(key)
     }
   }
   return $deepMap

--- a/deep-map/index.js
+++ b/deep-map/index.js
@@ -1,7 +1,7 @@
 import { atom } from '../atom/index.js'
 import { getPath, setPath } from './path.js'
 
-export { getPath, setPath } from './path.js'
+export { getPath, setByKey, setPath } from './path.js'
 
 export function deepMap(initial = {}) {
   let $deepMap = atom(initial)

--- a/deep-map/index.js
+++ b/deep-map/index.js
@@ -6,14 +6,9 @@ export { getPath, setByKey, setPath } from './path.js'
 export function deepMap(initial = {}) {
   let $deepMap = atom(initial)
   $deepMap.setKey = (key, value) => {
-    let oldValue
-    try {
-      oldValue = structuredClone($deepMap.value)
-    } catch {
-      oldValue = { ...$deepMap.value }
-    }
     if (getPath($deepMap.value, key) !== value) {
-      $deepMap.value = { ...setPath($deepMap.value, key, value) }
+      let oldValue = $deepMap.value
+      $deepMap.value = setPath($deepMap.value, key, value)
       $deepMap.notify(oldValue, key)
     }
   }

--- a/deep-map/index.js
+++ b/deep-map/index.js
@@ -6,7 +6,7 @@ export { getPath, setByKey, setPath } from './path.js'
 export function deepMap(initial = {}) {
   let $deepMap = atom(initial)
   $deepMap.setKey = (key, value) => {
-    if (getPath($deepMap.value, key) !== value) {
+    if (!$deepMap.isEqual(getPath($deepMap.value, key), value)) {
       $deepMap.value = setPath($deepMap.value, key, value)
       $deepMap.notify(key)
     }

--- a/deep-map/index.test.ts
+++ b/deep-map/index.test.ts
@@ -299,16 +299,18 @@ test('deletes keys on undefined value', () => {
   deepStrictEqual(keys, [['a'], []])
 })
 
-test('does not mutate listeners while change event', () => {
+test('does not run queued listeners after they are unsubscribed', () => {
   let events: string[] = []
   let $store = deepMap<{ a: number }>({ a: 0 })
 
   $store.listen(value => {
     events.push(`a${value.a}`)
-    unbindB()
     $store.listen(v => {
       events.push(`c${v.a}`)
     })
+    if (value.a > 1) {
+      unbindB()
+    }
   })
 
   let unbindB = $store.listen(value => {

--- a/deep-map/path.d.ts
+++ b/deep-map/path.d.ts
@@ -122,3 +122,25 @@ export function setPath<T extends BaseDeepMap, K extends AllPaths<T>>(
   path: K,
   value: FromPath<T, K>
 ): T
+
+/**
+ * Set a deep value by path. Initialized arrays with `undefined`
+ * if you set arbitrary length.
+ *
+ * ```
+ * import { setByKey } from 'nanostores'
+ *
+ * setByKey({ a: { b: { c: [] } } }, ['a', 'b', 'c', 1], 'hey')
+ * // Returns `{ a: { b: { c: [undefined, 'hey'] } } }`
+ * ```
+ *
+ * @param obj Any object.
+ * @param splittedKeys An array of keys representing the path to the value.
+ * @param value New value.
+ * @retunts The new object.
+ */
+export function setByKey<T extends BaseDeepMap>(
+  obj: T,
+  splittedKeys: PropertyKey[],
+  value: unknown
+): T;

--- a/deep-map/path.d.ts
+++ b/deep-map/path.d.ts
@@ -103,14 +103,16 @@ export function getPath<T extends BaseDeepMap, K extends AllPaths<T>>(
 ): FromPath<T, K>
 
 /**
- * Set a deep value by key. Initialized arrays with `undefined`
- * if you set arbitrary length.
+ * Set a deep value by key. Makes a copy at each level of `path` so the input
+ * object is not mutated (but does not do a full deep copy -- references to
+ * objects will still be shared between input and output). Sparse arrays will
+ * be created if you set arbitrary length.
  *
  * ```
  * import { setPath } from 'nanostores'
  *
  * setPath({ a: { b: { c: [] } } }, 'a.b.c[1]', 'hey')
- * // Returns `{ a: { b: { c: [undefined, 'hey'] } } }`
+ * // Returns `{ a: { b: { c: [<empty>, 'hey'] } } }`
  * ```
  *
  * @param obj Any object.
@@ -124,14 +126,16 @@ export function setPath<T extends BaseDeepMap, K extends AllPaths<T>>(
 ): T
 
 /**
- * Set a deep value by path. Initialized arrays with `undefined`
- * if you set arbitrary length.
+ * Set a deep value by path. Makes a copy at each level of `path` so the input
+ * object is not mutated (but does not do a full deep copy -- references to
+ * objects will still be shared between input and output). Sparse arrays will
+ * be created if you set arbitrary length.
  *
  * ```
  * import { setByKey } from 'nanostores'
  *
  * setByKey({ a: { b: { c: [] } } }, ['a', 'b', 'c', 1], 'hey')
- * // Returns `{ a: { b: { c: [undefined, 'hey'] } } }`
+ * // Returns `{ a: { b: { c: [<empty>, 'hey'] } } }`
  * ```
  *
  * @param obj Any object.

--- a/deep-map/path.js
+++ b/deep-map/path.js
@@ -14,7 +14,7 @@ export function setPath(obj, path, value) {
   return setByKey(obj != null ? obj : {}, getAllKeysFromPath(path), value)
 }
 
-function setByKey(obj, splittedKeys, value) {
+export function setByKey(obj, splittedKeys, value) {
   let key = splittedKeys[0]
   ensureKey(obj, key, splittedKeys[1])
   let copy = Array.isArray(obj) ? [...obj] : { ...obj }

--- a/deep-map/path.js
+++ b/deep-map/path.js
@@ -16,11 +16,10 @@ export function setPath(obj, path, value) {
 
 export function setByKey(obj, splittedKeys, value) {
   let key = splittedKeys[0]
-  ensureKey(obj, key, splittedKeys[1])
   let copy = Array.isArray(obj) ? [...obj] : { ...obj }
   if (splittedKeys.length === 1) {
     if (value === undefined) {
-      if (Array.isArray(obj)) {
+      if (Array.isArray(copy)) {
         copy.splice(key, 1)
       } else {
         delete copy[key]
@@ -30,9 +29,9 @@ export function setByKey(obj, splittedKeys, value) {
     }
     return copy
   }
-  let newVal = setByKey(obj[key], splittedKeys.slice(1), value)
-  obj[key] = newVal
-  return obj
+  ensureKey(copy, key, splittedKeys[1])
+  copy[key] = setByKey(copy[key], splittedKeys.slice(1), value)
+  return copy
 }
 
 const ARRAY_INDEX = /(.*)\[(\d+)\]/
@@ -58,7 +57,7 @@ function ensureKey(obj, key, nextKey) {
   let isNum = IS_NUMBER.test(nextKey)
 
   if (isNum) {
-    obj[key] = Array(parseInt(nextKey, 10) + 1).fill(undefined)
+    obj[key] = Array(parseInt(nextKey, 10) + 1)
   } else {
     obj[key] = {}
   }

--- a/index.d.ts
+++ b/index.d.ts
@@ -20,7 +20,7 @@ export {
   onStop,
   STORE_UNMOUNT_DELAY
 } from './lifecycle/index.js'
-export { listenKeys, subscribeKeys } from './listen-keys/index.js'
+export { listenKeyPaths, listenKeys, subscribeKeyPaths, subscribeKeys } from './listen-keys/index.js'
 export { mapCreator, MapCreator } from './map-creator/index.js'
 export {
   AnyStore,

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-export { atom, Atom, ReadableAtom, WritableAtom } from './atom/index.js'
+export { atom, Atom, batch, ReadableAtom, WritableAtom } from './atom/index.js'
 export { clean, cleanStores } from './clean-stores/index.js'
 export { batched, computed } from './computed/index.js'
 export {

--- a/index.d.ts
+++ b/index.d.ts
@@ -19,7 +19,7 @@ export {
   onStop,
   STORE_UNMOUNT_DELAY
 } from './lifecycle/index.js'
-export { listenKeys } from './listen-keys/index.js'
+export { listenKeys, subscribeKeys } from './listen-keys/index.js'
 export { mapCreator, MapCreator } from './map-creator/index.js'
 export {
   AnyStore,

--- a/index.d.ts
+++ b/index.d.ts
@@ -8,6 +8,7 @@ export {
   DeepMapStore,
   FromPath,
   getPath,
+  setByKey,
   setPath
 } from './deep-map/index.js'
 export { keepMount } from './keep-mount/index.js'

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ export {
   onStop,
   STORE_UNMOUNT_DELAY
 } from './lifecycle/index.js'
-export { listenKeys } from './listen-keys/index.js'
+export { listenKeys, subscribeKeys } from './listen-keys/index.js'
 export { mapCreator } from './map-creator/index.js'
 export { map } from './map/index.js'
 export { allTasks, cleanTasks, startTask, task } from './task/index.js'

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 export { atom } from './atom/index.js'
 export { clean, cleanStores } from './clean-stores/index.js'
 export { batched, computed } from './computed/index.js'
-export { deepMap, getPath, setPath } from './deep-map/index.js'
+export { deepMap, getPath, setByKey, setPath } from './deep-map/index.js'
 export { keepMount } from './keep-mount/index.js'
 export {
   onMount,

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ export {
   onStop,
   STORE_UNMOUNT_DELAY
 } from './lifecycle/index.js'
-export { listenKeys, subscribeKeys } from './listen-keys/index.js'
+export { listenKeyPaths, listenKeys, subscribeKeyPaths, subscribeKeys } from './listen-keys/index.js'
 export { mapCreator } from './map-creator/index.js'
 export { map } from './map/index.js'
 export { allTasks, cleanTasks, startTask, task } from './task/index.js'

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-export { atom } from './atom/index.js'
+export { atom, batch } from './atom/index.js'
 export { clean, cleanStores } from './clean-stores/index.js'
 export { batched, computed } from './computed/index.js'
 export { deepMap, getPath, setByKey, setPath } from './deep-map/index.js'

--- a/lifecycle/index.js
+++ b/lifecycle/index.js
@@ -98,14 +98,16 @@ export let onSet = ($store, listener) =>
 export let onNotify = ($store, listener) =>
   on($store, listener, NOTIFY, runListeners => {
     let originNotify = $store.notify
-    $store.notify = (oldValue, changed) => {
+    let oldValue = $store.value
+    $store.notify = (changed) => {
       let isAborted
       let abort = () => {
         isAborted = true
       }
-
-      runListeners({ abort, changed, oldValue })
-      if (!isAborted) return originNotify(oldValue, changed)
+      let currentOldValue = oldValue
+      oldValue = $store.value
+      runListeners({ abort, changed, oldValue: currentOldValue })
+      if (!isAborted) return originNotify(changed)
     }
     return () => {
       $store.notify = originNotify

--- a/listen-keys/index.d.ts
+++ b/listen-keys/index.d.ts
@@ -3,14 +3,15 @@ import type { StoreValue } from '../map/index.js'
 /**
  * Listen for specific keys of the store.
  *
- * In contrast with {@link subscribeKeys} it do not call listener
+ * In contrast with {@link subscribeKeys} it does not call listener
  * immediately.
+ *
  * ```js
  * import { listenKeys } from 'nanostores'
  *
- * listenKeys($page, ['blocked'], (value, oldValue, changed) => {
+ * listenKeys($page, ['blocked'], (value, oldValue) => {
  *   if (value.blocked) {
- *     console.log('You has no access')
+ *     console.log('You have no access')
  *   }
  * })
  * ```
@@ -29,11 +30,6 @@ export function listenKeys<
   listener: (
     value: StoreValue<SomeStore>,
     oldValue: StoreValue<SomeStore>,
-    changed: SomeStore extends {
-      setKey: (key: infer Key, value: never) => unknown
-    }
-      ? Key[]
-      : never
   ) => void
 ): () => void
 
@@ -45,9 +41,9 @@ export function listenKeys<
  * ```js
  * import { subscribeKeys } from 'nanostores'
  *
- * subscribeKeys($page, ['blocked'], (value, oldValue, changed) => {
+ * subscribeKeys($page, ['blocked'], (value, oldValue) => {
  *   if (value.blocked) {
- *     console.log('You has no access')
+ *     console.log('You have no access')
  *   }
  * })
  * ```
@@ -65,10 +61,75 @@ export function subscribeKeys<
     : never,
   listener: (
     value: StoreValue<SomeStore>,
-    changed: SomeStore extends {
-      setKey: (key: infer Key, value: never) => unknown
-    }
-      ? Key[]
-      : never
+    oldValue: StoreValue<SomeStore>,
+  ) => void
+): () => void
+
+/**
+ * Listen for specific key paths of the store, using object path syntax as
+ * passed to `getPath`.
+ *
+ * In contrast with {@link subscribeKeyPaths} it does not call listener
+ * immediately.
+ *
+ * ```js
+ * import { listenKeyPaths } from 'nanostores'
+ *
+ * listenKeyPaths($page, ['auth.blocked'], (value, oldValue) => {
+ *   if (value.auth.blocked) {
+ *     console.log('You have no access')
+ *   }
+ * })
+ * ```
+ *
+ * @param $store The store to listen.
+ * @param keyPaths Key paths splitted by dots and `[]`. Like:
+ *                 `props.arr[1].nested`.
+ * @param listener Standard listener.
+ */
+export function listenKeyPaths<
+  SomeStore extends { setKey: (key: any, value: any) => void }
+>(
+  $store: SomeStore,
+  keyPaths: SomeStore extends { setKey: (key: infer Key, value: never) => unknown }
+    ? readonly Key[]
+    : never,
+  listener: (
+    value: StoreValue<SomeStore>,
+    oldValue: StoreValue<SomeStore>,
+  ) => void
+): () => void
+
+/**
+ * Listen for specific key paths of the store, using object path syntax as
+ * passed to `getPath`, and call listener immediately.
+ * Note that the oldValue and changed arguments in the listener are
+ * undefined during the initial call.
+ *
+ * ```js
+ * import { subscribeKeys } from 'nanostores'
+ *
+ * subscribeKeyPaths($page, ['auth.blocked'], (value, oldValue) => {
+ *   if (value.auth.blocked) {
+ *     console.log('You have no access')
+ *   }
+ * })
+ * ```
+ *
+ * @param $store The store to listen.
+ * @param keyPaths Key paths splitted by dots and `[]`. Like:
+ *                 `props.arr[1].nested`.
+ * @param listener Standard listener.
+ */
+export function subscribeKeyPaths<
+  SomeStore extends { setKey: (key: any, value: any) => void }
+>(
+  $store: SomeStore,
+  keyPaths: SomeStore extends { setKey: (key: infer Key, value: never) => unknown }
+    ? readonly Key[]
+    : never,
+  listener: (
+    value: StoreValue<SomeStore>,
+    oldValue: StoreValue<SomeStore>,
   ) => void
 ): () => void

--- a/listen-keys/index.d.ts
+++ b/listen-keys/index.d.ts
@@ -3,11 +3,15 @@ import type { StoreValue } from '../map/index.js'
 /**
  * Listen for specific keys of the store.
  *
+ * In contrast with {@link subscribeKeys} it do not call listener
+ * immediately.
  * ```js
  * import { listenKeys } from 'nanostores'
  *
- * listenKeys($page, ['blocked'], () => {
- *   console.log('You has no access')
+ * listenKeys($page, ['blocked'], (value, oldValue, changed) => {
+ *   if (value.blocked) {
+ *     console.log('You has no access')
+ *   }
  * })
  * ```
  *
@@ -25,6 +29,42 @@ export function listenKeys<
   listener: (
     value: StoreValue<SomeStore>,
     oldValue: StoreValue<SomeStore>,
+    changed: SomeStore extends {
+      setKey: (key: infer Key, value: never) => unknown
+    }
+      ? Key[]
+      : never
+  ) => void
+): () => void
+
+/**
+ * Listen for specific keys of the store and call listener immediately.
+ * Note that the oldValue and changed arguments in the listener are
+ * undefined during the initial call.
+ *
+ * ```js
+ * import { subscribeKeys } from 'nanostores'
+ *
+ * subscribeKeys($page, ['blocked'], (value, oldValue, changed) => {
+ *   if (value.blocked) {
+ *     console.log('You has no access')
+ *   }
+ * })
+ * ```
+ *
+ * @param $store The store to listen.
+ * @param keys The keys to listen.
+ * @param listener Standard listener.
+ */
+export function subscribeKeys<
+  SomeStore extends { setKey: (key: any, value: any) => void }
+>(
+  $store: SomeStore,
+  keys: SomeStore extends { setKey: (key: infer Key, value: never) => unknown }
+    ? readonly Key[]
+    : never,
+  listener: (
+    value: StoreValue<SomeStore>,
     changed: SomeStore extends {
       setKey: (key: infer Key, value: never) => unknown
     }

--- a/listen-keys/index.js
+++ b/listen-keys/index.js
@@ -1,14 +1,29 @@
+import { getPath } from '../index.js'
+
 export function listenKeys($store, keys, listener) {
-  let keysSet = new Set([...keys, undefined])
-  return $store.listen((value, oldValue, changed) => {
-    if (keysSet.has(changed)) {
-      listener(value, oldValue, changed)
+  return $store.listen((value, oldValue) => {
+    if (keys.some(key => !$store.isEqual(value[key], oldValue[key]))) {
+      listener(value, oldValue)
     }
   })
 }
 
 export function subscribeKeys($store, keys, listener) {
   let unbind = listenKeys($store, keys, listener)
+  listener($store.value)
+  return unbind
+}
+
+export function listenKeyPaths($store, keys, listener) {
+  return $store.listen((value, oldValue) => {
+    if (keys.some(key => !$store.isEqual(getPath(value, key), getPath(oldValue, key)))) {
+      listener(value, oldValue)
+    }
+  })
+}
+
+export function subscribeKeyPaths($store, keys, listener) {
+  let unbind = listenKeyPaths($store, keys, listener)
   listener($store.value)
   return unbind
 }

--- a/listen-keys/index.js
+++ b/listen-keys/index.js
@@ -6,3 +6,9 @@ export function listenKeys($store, keys, listener) {
     }
   })
 }
+
+export function subscribeKeys($store, keys, listener) {
+  let unbind = listenKeys($store, keys, listener)
+  listener($store.value)
+  return unbind
+}

--- a/listen-keys/index.test.ts
+++ b/listen-keys/index.test.ts
@@ -1,7 +1,7 @@
 import { deepStrictEqual, equal } from 'node:assert'
 import { test } from 'node:test'
 
-import { deepMap, listenKeys, map } from '../index.js'
+import { deepMap, listenKeys, map, subscribeKeys } from '../index.js'
 
 test('listen for specific keys', () => {
   let events: string[] = []
@@ -54,4 +54,30 @@ test('allows setting specific deep keys', () => {
   $store.setKey('a.f[0][1]', { g: 0 })
   $store.setKey('a.f[0][0].g', 5)
   deepStrictEqual(events, ['e2', 'd[2]', 'd[1]4', 'g5'])
+})
+
+test('can subscribe to changes and call listener immediately', () => {
+  let events: string[] = []
+  let $store = map({ a: 1, b: 1 })
+
+  let unbind = subscribeKeys($store, ['a'], value => {
+    events.push(`${value.a} ${value.b}`)
+  })
+  deepStrictEqual(events, ['1 1'])
+
+  $store.setKey('b', 2)
+  deepStrictEqual(events, ['1 1'])
+
+  $store.setKey('a', 2)
+  deepStrictEqual(events, ['1 1', '2 2'])
+
+  $store.setKey('a', 3)
+  deepStrictEqual(events, ['1 1', '2 2', '3 2'])
+
+  $store.setKey('b', 3)
+  deepStrictEqual(events, ['1 1', '2 2', '3 2'])
+
+  unbind()
+  $store.setKey('a', 4)
+  deepStrictEqual(events, ['1 1', '2 2', '3 2'])
 })

--- a/listen-keys/index.test.ts
+++ b/listen-keys/index.test.ts
@@ -1,14 +1,13 @@
-import { deepStrictEqual, equal } from 'node:assert'
+import { deepStrictEqual } from 'node:assert'
 import { test } from 'node:test'
 
-import { deepMap, listenKeys, map, subscribeKeys } from '../index.js'
+import { batch, deepMap, listenKeyPaths, listenKeys, map, setPath, subscribeKeyPaths, subscribeKeys } from '../index.js'
 
-test('listen for specific keys', () => {
+test('listen for specific keys changed via setKey', () => {
   let events: string[] = []
   let $store = map({ a: 1, b: 1 })
 
-  let unbind = listenKeys($store, ['a'], (value, _, changed) => {
-    equal(changed, 'a')
+  let unbind = listenKeys($store, ['a'], (value) => {
     events.push(`${value.a} ${value.b}`)
   })
   deepStrictEqual(events, [])
@@ -30,20 +29,46 @@ test('listen for specific keys', () => {
   deepStrictEqual(events, ['2 2', '3 2'])
 })
 
-test('allows setting specific deep keys', () => {
+test('listens for specific keys changed via set', () => {
+  let events: string[] = []
+  let $store = map({ a: 1, b: 1 })
+
+  let unbind = listenKeys($store, ['a'], (value) => {
+    events.push(`${value.a} ${value.b}`)
+  })
+  deepStrictEqual(events, [])
+
+  $store.set({ a: 1, b: 2 })
+  deepStrictEqual(events, [])
+
+  $store.set({ a: 2, b: 2 })
+  deepStrictEqual(events, ['2 2'])
+
+  $store.set({ a: 3, b: 2 })
+  deepStrictEqual(events, ['2 2', '3 2'])
+
+  $store.set({ a: 3, b: 3 })
+  deepStrictEqual(events, ['2 2', '3 2'])
+
+  unbind()
+  $store.set({ a: 4, b: 3 })
+  deepStrictEqual(events, ['2 2', '3 2'])
+})
+
+test('allows setting specific deep keys changed via setKey', () => {
   let events: string[] = []
   let $store = deepMap({ a: { b: { c: { d: [1] } }, e: 1, f: [[{ g: 1 }]] } })
 
-  listenKeys($store, ['a.e'], value => {
+  listenKeyPaths($store, ['a.e'], value => {
     events.push(`e${value.a.e}`)
   })
-  listenKeys($store, ['a.b.c.d'], value => {
+  listenKeyPaths($store, ['a.b.c.d'], value => {
     events.push(`d${JSON.stringify(value.a.b.c.d)}`)
   })
-  listenKeys($store, ['a.b.c.d[1]'], value => {
+  listenKeyPaths($store, ['a.b.c.d[1]'], value => {
     events.push(`d[1]${value.a.b.c.d[1]}`)
   })
-  listenKeys($store, ['a.f[0][0].g'], value => {
+  listenKeyPaths($store, ['a.f[0][0].g'], value => {
     events.push(`g${value.a.f[0][0].g}`)
   })
 
@@ -53,7 +78,33 @@ test('allows setting specific deep keys', () => {
   $store.setKey('a.b.c.d[1]', 4)
   $store.setKey('a.f[0][1]', { g: 0 })
   $store.setKey('a.f[0][0].g', 5)
-  deepStrictEqual(events, ['e2', 'd[2]', 'd[1]4', 'g5'])
+  deepStrictEqual(events, ['e2', 'd[2]', 'd[3]', 'd[3,4]', 'd[1]4', 'g5'])
+})
+
+test('allows setting specific deep keys changed via set', () => {
+  let events: string[] = []
+  let $store = deepMap({ a: { b: { c: { d: [1] } }, e: 1, f: [[{ g: 1 }]] } })
+
+  listenKeyPaths($store, ['a.e'], value => {
+    events.push(`e${value.a.e}`)
+  })
+  listenKeyPaths($store, ['a.b.c.d'], value => {
+    events.push(`d${JSON.stringify(value.a.b.c.d)}`)
+  })
+  listenKeyPaths($store, ['a.b.c.d[1]'], value => {
+    events.push(`d[1]${value.a.b.c.d[1]}`)
+  })
+  listenKeyPaths($store, ['a.f[0][0].g'], value => {
+    events.push(`g${value.a.f[0][0].g}`)
+  })
+
+  $store.set(setPath($store.value!, 'a.e', 2))
+  $store.set(setPath($store.value!, 'a.b.c.d', [2]))
+  $store.set(setPath($store.value!, 'a.b.c.d[0]', 3))
+  $store.set(setPath($store.value!, 'a.b.c.d[1]', 4))
+  $store.set(setPath($store.value!, 'a.f[0][1]', { g: 0 }))
+  $store.set(setPath($store.value!, 'a.f[0][0].g', 5))
+  deepStrictEqual(events, ['e2', 'd[2]', 'd[3]', 'd[3,4]', 'd[1]4', 'g5'])
 })
 
 test('can subscribe to changes and call listener immediately', () => {
@@ -80,4 +131,36 @@ test('can subscribe to changes and call listener immediately', () => {
   unbind()
   $store.setKey('a', 4)
   deepStrictEqual(events, ['1 1', '2 2', '3 2'])
+})
+
+test('subscribeKeyPaths', () => {
+  let events: string[] = []
+  let $store = deepMap({ a: { b: 1 } })
+
+  subscribeKeyPaths($store, ['a.b'], value => {
+    events.push(`b${value.a.b}`)
+  })
+
+  $store.set({ a: { b: 2 } })
+  deepStrictEqual(events, ['b1', 'b2'])
+})
+
+test('store is changed multiple times in a batch', () => {
+  let events: string[] = []
+  let $store = map({ a: 1, b: 1 })
+
+  let unbind = listenKeys($store, ['a'], (value) => {
+    events.push(`${value.a} ${value.b}`)
+  })
+  deepStrictEqual(events, [])
+
+  batch(() => {
+    $store.setKey('b', 2)
+    $store.setKey('a', 2)
+    $store.setKey('a', 3)
+    $store.setKey('b', 3)
+  })
+
+  deepStrictEqual(events, ['3 3'])
+  unbind()
 })

--- a/map/index.d.ts
+++ b/map/index.d.ts
@@ -58,6 +58,14 @@ export interface MapStore<Value extends object = any>
   ): () => void
 
   /**
+   * Low-level method to notify listeners about changes in the store.
+   *
+   * Can cause unexpected behaviour when combined with frontend frameworks
+   * that perform equality checks for values, such as React.
+   */
+  notify(oldValue?: ReadonlyIfObject<Value>, changedKey?: AllKeys<Value>): void
+
+  /**
    * Change store value.
    *
    * ```js

--- a/map/index.d.ts
+++ b/map/index.d.ts
@@ -58,14 +58,6 @@ export interface MapStore<Value extends object = any>
   ): () => void
 
   /**
-   * Low-level method to notify listeners about changes in the store.
-   *
-   * Can cause unexpected behaviour when combined with frontend frameworks
-   * that perform equality checks for values, such as React.
-   */
-  notify(oldValue?: ReadonlyIfObject<Value>, changedKey?: AllKeys<Value>): void
-
-  /**
    * Change store value.
    *
    * ```js

--- a/map/index.js
+++ b/map/index.js
@@ -4,17 +4,16 @@ export let map = (initial = {}) => {
   let $map = atom(initial)
 
   $map.setKey = function (key, value) {
-    let oldMap = $map.value
     if (typeof value === 'undefined' && key in $map.value) {
       $map.value = { ...$map.value }
       delete $map.value[key]
-      $map.notify(oldMap, key)
+      $map.notify(key)
     } else if ($map.value[key] !== value) {
       $map.value = {
         ...$map.value,
         [key]: value
       }
-      $map.notify(oldMap, key)
+      $map.notify(key)
     }
   }
 

--- a/map/index.js
+++ b/map/index.js
@@ -8,7 +8,7 @@ export let map = (initial = {}) => {
       $map.value = { ...$map.value }
       delete $map.value[key]
       $map.notify(key)
-    } else if ($map.value[key] !== value) {
+    } else if (!$map.isEqual($map.value[key], value)) {
       $map.value = {
         ...$map.value,
         [key]: value

--- a/map/index.test.ts
+++ b/map/index.test.ts
@@ -299,16 +299,18 @@ test('deletes keys on undefined value', () => {
   deepStrictEqual(keys, [['a'], []])
 })
 
-test('does not mutate listeners while change event', () => {
+test('does not run queued listeners after they are unsubscribed', () => {
   let events: string[] = []
   let $store = map<{ a: number }>({ a: 0 })
 
   $store.listen(value => {
     events.push(`a${value.a}`)
-    unbindB()
     $store.listen(v => {
       events.push(`c${v.a}`)
     })
+    if (value.a > 1) {
+      unbindB()
+    }
   })
 
   let unbindB = $store.listen(value => {

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
       "import": {
         "./index.js": "{ map, computed, }"
       },
-      "limit": "806 B"
+      "limit": "814 B"
     }
   ],
   "clean-publish": {

--- a/package.json
+++ b/package.json
@@ -92,14 +92,14 @@
       "import": {
         "./index.js": "{ atom }"
       },
-      "limit": "287 B"
+      "limit": "303 B"
     },
     {
       "name": "Popular Set",
       "import": {
         "./index.js": "{ map, computed, }"
       },
-      "limit": "818 B"
+      "limit": "830 B"
     }
   ],
   "clean-publish": {

--- a/package.json
+++ b/package.json
@@ -92,14 +92,14 @@
       "import": {
         "./index.js": "{ atom }"
       },
-      "limit": "283 B"
+      "limit": "336 B"
     },
     {
       "name": "Popular Set",
       "import": {
         "./index.js": "{ map, computed, }"
       },
-      "limit": "822 B"
+      "limit": "876 B"
     }
   ],
   "clean-publish": {

--- a/package.json
+++ b/package.json
@@ -92,14 +92,14 @@
       "import": {
         "./index.js": "{ atom }"
       },
-      "limit": "235 B"
+      "limit": "251 B"
     },
     {
       "name": "Popular Set",
       "import": {
         "./index.js": "{ map, computed, }"
       },
-      "limit": "769 B"
+      "limit": "786 B"
     }
   ],
   "clean-publish": {

--- a/package.json
+++ b/package.json
@@ -92,14 +92,14 @@
       "import": {
         "./index.js": "{ atom }"
       },
-      "limit": "250 B"
+      "limit": "265 B"
     },
     {
       "name": "Popular Set",
       "import": {
         "./index.js": "{ map, computed, }"
       },
-      "limit": "786 B"
+      "limit": "806 B"
     }
   ],
   "clean-publish": {

--- a/package.json
+++ b/package.json
@@ -92,14 +92,14 @@
       "import": {
         "./index.js": "{ atom }"
       },
-      "limit": "265 B"
+      "limit": "283 B"
     },
     {
       "name": "Popular Set",
       "import": {
         "./index.js": "{ map, computed, }"
       },
-      "limit": "814 B"
+      "limit": "822 B"
     }
   ],
   "clean-publish": {

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
       "import": {
         "./index.js": "{ atom }"
       },
-      "limit": "251 B"
+      "limit": "250 B"
     },
     {
       "name": "Popular Set",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nanostores",
   "version": "0.10.3",
-  "description": "A tiny (286 bytes) state manager for React/Preact/Vue/Svelte with many atomic tree-shakable stores",
+  "description": "A tiny (287 bytes) state manager for React/Preact/Vue/Svelte with many atomic tree-shakable stores",
   "keywords": [
     "store",
     "state",
@@ -92,7 +92,7 @@
       "import": {
         "./index.js": "{ atom }"
       },
-      "limit": "286 B"
+      "limit": "287 B"
     },
     {
       "name": "Popular Set",

--- a/package.json
+++ b/package.json
@@ -92,14 +92,14 @@
       "import": {
         "./index.js": "{ atom }"
       },
-      "limit": "303 B"
+      "limit": "302 B"
     },
     {
       "name": "Popular Set",
       "import": {
         "./index.js": "{ map, computed, }"
       },
-      "limit": "830 B"
+      "limit": "831 B"
     }
   ],
   "clean-publish": {

--- a/package.json
+++ b/package.json
@@ -92,14 +92,14 @@
       "import": {
         "./index.js": "{ atom }"
       },
-      "limit": "302 B"
+      "limit": "235 B"
     },
     {
       "name": "Popular Set",
       "import": {
         "./index.js": "{ map, computed, }"
       },
-      "limit": "831 B"
+      "limit": "769 B"
     }
   ],
   "clean-publish": {


### PR DESCRIPTION
Supersedes #298. See the description of that PR for the overview. Changes in this version:

* Based on `next` branch instead of `main`
* Fixes stale values and listeners being called multiple times when batching
* Removes `notify` from the public types, adds overridable `isEqual` function as alternative
* Fixes listenKeys/subscribeKeys to work with `batch`
* Adds documentation

There are more details about each of those bullet points in the commit messages. It's probably best to start by looking at the commits individually rather than all the changes together.
