### PR TITLE
Fix docs mentioning structuredClone, no longer applies after #305

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,18 +270,9 @@ $profile.setKey('hobbies[0].friends[0].name', 'Leslie Knope')
 $profile.setKey('skills[0][0]', 'Whittling')
 ```
 
-Note that Deep Maps have a mutable state at the second level of nesting,
-and it uses [`structuredClone`] to get the previous value of the state
-for listeners such as `store.listen(cb)`, `store.subscribe(cb)`
-and `onNotify(store, cb)`.
-
-So, to get the correct previous value in the listener, you should use
-[transferable objects] in the store value.
-
-[`structuredClone`]: https://developer.mozilla.org/en-US/docs/Web/API/structuredClone#browser_compatibility
-[transferable objects]: https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Transferable_objects
-
-
+Note that `setKey` creates copies as necessary so that no part of the original
+object is mutated (but it does not do a full deep copy -- some sub-objects may
+still be shared between the old value and the new one).
 
 ### Lazy Stores
 

--- a/deep-map/index.d.ts
+++ b/deep-map/index.d.ts
@@ -33,8 +33,9 @@ export type DeepMapStore<T extends BaseDeepMap> = {
 
   /**
    * Change key in store value. Copies are made at each level of `key` so that
-   * the old value is not mutated (but it does not do a full deep copy --
-   * references to objects will still be shared between the old and new value).
+   * no part of the original object is mutated (but it does not do a full deep
+   * copy -- some sub-objects may still be shared between the old value and the
+   * new one).
    *
    * ```js
    * $settings.setKey('visuals.theme', 'dark')

--- a/deep-map/path.d.ts
+++ b/deep-map/path.d.ts
@@ -103,10 +103,10 @@ export function getPath<T extends BaseDeepMap, K extends AllPaths<T>>(
 ): FromPath<T, K>
 
 /**
- * Set a deep value by key. Makes a copy at each level of `path` so the input
- * object is not mutated (but does not do a full deep copy -- references to
- * objects will still be shared between input and output). Sparse arrays will
- * be created if you set arbitrary length.
+ * Set a deep value by path. Copies are made at each level of `path` so that no
+ * part of the original object is mutated (but it does not do a full deep copy
+ * -- some sub-objects may still be shared between the old value and the new
+ * one). Sparse arrays will be created if you set arbitrary length.
  *
  * ```
  * import { setPath } from 'nanostores'
@@ -126,10 +126,10 @@ export function setPath<T extends BaseDeepMap, K extends AllPaths<T>>(
 ): T
 
 /**
- * Set a deep value by path. Makes a copy at each level of `path` so the input
- * object is not mutated (but does not do a full deep copy -- references to
- * objects will still be shared between input and output). Sparse arrays will
- * be created if you set arbitrary length.
+ * Set a deep value by key. Copies are made at each level of `path` so that no
+ * part of the original object is mutated (but it does not do a full deep copy
+ * -- some sub-objects may still be shared between the old value and the new
+ * one). Sparse arrays will be created if you set arbitrary length.
  *
  * ```
  * import { setByKey } from 'nanostores'


### PR DESCRIPTION
Also cleans up related jsdocs