### PR TITLE
Decrease size of computed function

### DIFF
--- a/computed/index.js
+++ b/computed/index.js
@@ -5,22 +5,17 @@ let computedStore = (stores, cb, batched) => {
   if (!Array.isArray(stores)) stores = [stores]
 
   let previousArgs
-  let currentRunId = 0
   let currentEpoch
   let set = () => {
     if (currentEpoch === epoch) return
     currentEpoch = epoch
     let args = stores.map($store => $store.get())
-    if (
-      previousArgs === undefined ||
-      args.some((arg, i) => arg !== previousArgs[i])
-    ) {
-      let runId = ++currentRunId
+    if (!previousArgs || args.some((arg, i) => arg !== previousArgs[i])) {
       previousArgs = args
       let value = cb(...args)
       if (value && value.then && value.t) {
         value.then(asyncValue => {
-          if (runId === currentRunId) {
+          if (previousArgs === args) {
             // Prevent a stale set
             $computed.set(asyncValue)
           }


### PR DESCRIPTION
Stripped out 14B.   The `currentRunId` is not really needed for tracking the stale state, since we already have `previousArgs` and `args`, which are sufficient.

I also covered staled behavior with test.