### PR TITLE
Add subscribe() tests

### DIFF
--- a/atom/index.test.ts
+++ b/atom/index.test.ts
@@ -125,6 +125,7 @@ test('supports complicated case of last unsubscribing', () => {
 
 test('supports the same listeners', () => {
   let events: (string | undefined)[] = []
+
   function listener(value: string | undefined): void {
     events.push(value)
   }
@@ -308,3 +309,35 @@ test('prevents notifying when new value is referentially equal to old one', () =
   unbind()
   clock.runAll()
 })
+
+test('notifies the subscribed listener with current and old values for a store that had an initial value', () => {
+  let events: (number | undefined)[] = []
+  let $store = atom<number>(1)
+
+  $store.subscribe((value, oldValue?: number) => {
+    events.push(oldValue, value)
+  })
+
+  $store.set(2)
+  equal(events, [1, 2])
+
+  $store.set(3)
+  equal(events, [1, 2, 2, 3])
+})
+
+test('notifies the subscribed listener with current and old values for a store that had no initial value', () => {
+  let events: (number | undefined)[] = []
+  let $store = atom<number | undefined>(undefined)
+
+  $store.subscribe((value, oldValue?: number) => {
+    events.push(oldValue, value)
+  })
+
+  $store.set(1)
+  equal(events, [undefined, 1])
+
+  $store.set(2)
+  equal(events, [undefined, 1, 1, 2])
+})
+
+test.run()


### PR DESCRIPTION
Adds some tests to inspect the behaviour of subscribe(), namely to ensure that the listener is actually receiving an old value of the atom