### PR TITLE
Add more subscribe() tests

### DIFF
--- a/atom/index.test.ts
+++ b/atom/index.test.ts
@@ -424,3 +424,32 @@ test('can use previous value in subscribers', () => {
   unbind()
   clock.runAll()
 })
+test('notifies the subscribed listener with current and old values for a store that had an initial value', () => {
+  let events: (number | undefined)[] = []
+  let $store = atom<number>(1)
+
+  $store.subscribe((value, oldValue?: number) => {
+    events.push(oldValue, value)
+  })
+
+  $store.set(2)
+  equal(events, [1, 2])
+
+  $store.set(3)
+  equal(events, [1, 2, 2, 3])
+})
+
+test('notifies the subscribed listener with current and old values for a store that had no initial value', () => {
+  let events: (number | undefined)[] = []
+  let $store = atom<number | undefined>(undefined)
+
+  $store.subscribe((value, oldValue?: number) => {
+    events.push(oldValue, value)
+  })
+
+  $store.set(1)
+  equal(events, [undefined, 1])
+
+  $store.set(2)
+  equal(events, [undefined, 1, 1, 2])
+})

--- a/atom/index.test.ts
+++ b/atom/index.test.ts
@@ -433,11 +433,13 @@ test('notifies the subscribed listener with current and old values for a store t
     events.push(oldValue, value)
   })
 
+  deepStrictEqual(events, [undefined, 1])
+
   $store.set(2)
-  equal(events, [1, 2])
+  deepStrictEqual(events, [undefined, 1, 1, 2])
 
   $store.set(3)
-  equal(events, [1, 2, 2, 3])
+  deepStrictEqual(events, [undefined, 1, 1, 2, 2, 3])
 })
 
 test('notifies the subscribed listener with current and old values for a store that had no initial value', () => {
@@ -448,9 +450,11 @@ test('notifies the subscribed listener with current and old values for a store t
     events.push(oldValue, value)
   })
 
+  deepStrictEqual(events, [undefined, undefined])
+
   $store.set(1)
-  equal(events, [undefined, 1])
+  deepStrictEqual(events, [undefined, undefined, undefined, 1])
 
   $store.set(2)
-  equal(events, [undefined, 1, 1, 2])
+  deepStrictEqual(events, [undefined, undefined, undefined, 1, 1, 2])
 })

--- a/atom/index.test.ts
+++ b/atom/index.test.ts
@@ -40,12 +40,9 @@ test('has default value', () => {
   let events: any[] = []
   let $time = atom()
   equal($time.value, undefined)
-  $time.listen(() => {
-  })
-  $time.listen(() => {
-  })
-  $time.listen(() => {
-  })
+  $time.listen(() => {})
+  $time.listen(() => {})
+  $time.listen(() => {})
   let unbind = $time.subscribe(value => {
     events.push(value)
   })
@@ -94,8 +91,7 @@ test('initializes store when it has listeners', () => {
   unbind2()
   deepStrictEqual(events, ['init', '1: new', '2: new', '2: new2'])
 
-  let unbind3 = $store.listen(() => {
-  })
+  let unbind3 = $store.listen(() => {})
   clock.runAll()
   deepStrictEqual(events, ['init', '1: new', '2: new', '2: new2'])
 
@@ -117,12 +113,10 @@ test('supports complicated case of last unsubscribing', () => {
     }
   })
 
-  let unbind1 = $store.listen(() => {
-  })
+  let unbind1 = $store.listen(() => {})
   unbind1()
 
-  let unbind2 = $store.listen(() => {
-  })
+  let unbind2 = $store.listen(() => {})
   unbind2()
 
   clock.runAll()
@@ -161,10 +155,8 @@ test('supports the same listeners', () => {
 
 test('supports double unsubscribe', () => {
   let $store = atom<string>('')
-  let unbind = $store.listen(() => {
-  })
-  $store.listen(() => {
-  })
+  let unbind = $store.listen(() => {})
+  $store.listen(() => {})
 
   unbind()
   unbind()
@@ -259,15 +251,13 @@ test('supports conditional destroy', () => {
     }
   })
 
-  let unbind1 = $store.listen(() => {
-  })
+  let unbind1 = $store.listen(() => {})
   unbind1()
   clock.runAll()
   deepStrictEqual(events, ['init', 'destroy'])
 
   destroyable = false
-  let unbind2 = $store.listen(() => {
-  })
+  let unbind2 = $store.listen(() => {})
   unbind2()
   clock.runAll()
   deepStrictEqual(events, ['init', 'destroy', 'init'])
@@ -437,7 +427,7 @@ test('can use previous value in subscribers', () => {
 })
 
 test('notifies the subscribed listener with current and old values for a store that had an initial value', () => {
-  let events: ({ oldValue: number | undefined, value: number | undefined })[] = []
+  let events: { oldValue: number | undefined; value: number | undefined }[] = []
   let $store = atom<number>(1)
 
   $store.subscribe((value, oldValue?: number) => {
@@ -447,14 +437,21 @@ test('notifies the subscribed listener with current and old values for a store t
   deepStrictEqual(events, [{ oldValue: undefined, value: 1 }])
 
   $store.set(2)
-  deepStrictEqual(events, [{ oldValue: undefined, value: 1 }, { oldValue: 1, value: 2 }])
+  deepStrictEqual(events, [
+    { oldValue: undefined, value: 1 },
+    { oldValue: 1, value: 2 }
+  ])
 
   $store.set(3)
-  deepStrictEqual(events, [{ oldValue: undefined, value: 1 }, { oldValue: 1, value: 2 }, { oldValue: 2, value: 3 }])
+  deepStrictEqual(events, [
+    { oldValue: undefined, value: 1 },
+    { oldValue: 1, value: 2 },
+    { oldValue: 2, value: 3 }
+  ])
 })
 
 test('notifies the subscribed listener with current and old values for a store that had no initial value', () => {
-  let events: ({ oldValue: number | undefined, value: number | undefined })[] = []
+  let events: { oldValue: number | undefined; value: number | undefined }[] = []
   let $store = atom<number | undefined>()
 
   $store.subscribe((value, oldValue?: number) => {
@@ -464,11 +461,18 @@ test('notifies the subscribed listener with current and old values for a store t
   deepStrictEqual(events, [{ oldValue: undefined, value: undefined }])
 
   $store.set(1)
-  deepStrictEqual(events, [{ oldValue: undefined, value: undefined }, { oldValue: undefined, value: 1 }])
+  deepStrictEqual(events, [
+    { oldValue: undefined, value: undefined },
+    { oldValue: undefined, value: 1 }
+  ])
 
   $store.set(2)
-  deepStrictEqual(events, [{ oldValue: undefined, value: undefined }, { oldValue: undefined, value: 1 }, {
-    oldValue: 1,
-    value: 2
-  }])
+  deepStrictEqual(events, [
+    { oldValue: undefined, value: undefined },
+    { oldValue: undefined, value: 1 },
+    {
+      oldValue: 1,
+      value: 2
+    }
+  ])
 })

--- a/atom/index.test.ts
+++ b/atom/index.test.ts
@@ -40,9 +40,12 @@ test('has default value', () => {
   let events: any[] = []
   let $time = atom()
   equal($time.value, undefined)
-  $time.listen(() => {})
-  $time.listen(() => {})
-  $time.listen(() => {})
+  $time.listen(() => {
+  })
+  $time.listen(() => {
+  })
+  $time.listen(() => {
+  })
   let unbind = $time.subscribe(value => {
     events.push(value)
   })
@@ -91,7 +94,8 @@ test('initializes store when it has listeners', () => {
   unbind2()
   deepStrictEqual(events, ['init', '1: new', '2: new', '2: new2'])
 
-  let unbind3 = $store.listen(() => {})
+  let unbind3 = $store.listen(() => {
+  })
   clock.runAll()
   deepStrictEqual(events, ['init', '1: new', '2: new', '2: new2'])
 
@@ -113,10 +117,12 @@ test('supports complicated case of last unsubscribing', () => {
     }
   })
 
-  let unbind1 = $store.listen(() => {})
+  let unbind1 = $store.listen(() => {
+  })
   unbind1()
 
-  let unbind2 = $store.listen(() => {})
+  let unbind2 = $store.listen(() => {
+  })
   unbind2()
 
   clock.runAll()
@@ -125,6 +131,7 @@ test('supports complicated case of last unsubscribing', () => {
 
 test('supports the same listeners', () => {
   let events: (string | undefined)[] = []
+
   function listener(value: string | undefined): void {
     events.push(value)
   }
@@ -154,8 +161,10 @@ test('supports the same listeners', () => {
 
 test('supports double unsubscribe', () => {
   let $store = atom<string>('')
-  let unbind = $store.listen(() => {})
-  $store.listen(() => {})
+  let unbind = $store.listen(() => {
+  })
+  $store.listen(() => {
+  })
 
   unbind()
   unbind()
@@ -250,13 +259,15 @@ test('supports conditional destroy', () => {
     }
   })
 
-  let unbind1 = $store.listen(() => {})
+  let unbind1 = $store.listen(() => {
+  })
   unbind1()
   clock.runAll()
   deepStrictEqual(events, ['init', 'destroy'])
 
   destroyable = false
-  let unbind2 = $store.listen(() => {})
+  let unbind2 = $store.listen(() => {
+  })
   unbind2()
   clock.runAll()
   deepStrictEqual(events, ['init', 'destroy', 'init'])
@@ -426,35 +437,38 @@ test('can use previous value in subscribers', () => {
 })
 
 test('notifies the subscribed listener with current and old values for a store that had an initial value', () => {
-  let events: (number | undefined)[] = []
+  let events: ({ oldValue: number | undefined, value: number | undefined })[] = []
   let $store = atom<number>(1)
 
   $store.subscribe((value, oldValue?: number) => {
-    events.push(oldValue, value)
+    events.push({ oldValue, value })
   })
 
-  deepStrictEqual(events, [undefined, 1])
+  deepStrictEqual(events, [{ oldValue: undefined, value: 1 }])
 
   $store.set(2)
-  deepStrictEqual(events, [undefined, 1, 1, 2])
+  deepStrictEqual(events, [{ oldValue: undefined, value: 1 }, { oldValue: 1, value: 2 }])
 
   $store.set(3)
-  deepStrictEqual(events, [undefined, 1, 1, 2, 2, 3])
+  deepStrictEqual(events, [{ oldValue: undefined, value: 1 }, { oldValue: 1, value: 2 }, { oldValue: 2, value: 3 }])
 })
 
 test('notifies the subscribed listener with current and old values for a store that had no initial value', () => {
-  let events: (number | undefined)[] = []
-  let $store = atom<number | undefined>(undefined)
+  let events: ({ oldValue: number | undefined, value: number | undefined })[] = []
+  let $store = atom<number | undefined>()
 
   $store.subscribe((value, oldValue?: number) => {
-    events.push(oldValue, value)
+    events.push({ oldValue, value })
   })
 
-  deepStrictEqual(events, [undefined, undefined])
+  deepStrictEqual(events, [{ oldValue: undefined, value: undefined }])
 
   $store.set(1)
-  deepStrictEqual(events, [undefined, undefined, undefined, 1])
+  deepStrictEqual(events, [{ oldValue: undefined, value: undefined }, { oldValue: undefined, value: 1 }])
 
   $store.set(2)
-  deepStrictEqual(events, [undefined, undefined, undefined, 1, 1, 2])
+  deepStrictEqual(events, [{ oldValue: undefined, value: undefined }, { oldValue: undefined, value: 1 }, {
+    oldValue: 1,
+    value: 2
+  }])
 })

--- a/atom/index.test.ts
+++ b/atom/index.test.ts
@@ -424,6 +424,7 @@ test('can use previous value in subscribers', () => {
   unbind()
   clock.runAll()
 })
+
 test('notifies the subscribed listener with current and old values for a store that had an initial value', () => {
   let events: (number | undefined)[] = []
   let $store = atom<number>(1)


### PR DESCRIPTION
Not sure why these fail, while the ones before testing the oldValue aren't.