### PR TITLE
Improve types

### DIFF
--- a/atom/errors.ts
+++ b/atom/errors.ts
@@ -1,4 +1,4 @@
-import { atom, WritableAtom } from '../index.js'
+import { atom, ReadableAtom } from '../index.js'
 
 let $store = atom<{ value: string }>({ value: '1' })
 
@@ -15,16 +15,21 @@ let fn = $fnStore.get()
 fn()
 
 let $store2 = atom<string | undefined>()
-$store2.set("new")
+$store2.set('new')
+// THROWS Type 'string | undefined' is not assignable to type 'string'.
+let store2value: string = $store2.value
 
 // THROWS Expected 1 arguments, but got 0
 let $store3 = atom<string>()
 
-declare const scoreSym:unique symbol
-export type scoreType = number&{ [scoreSym]:any }
+declare const scoreSym: unique symbol
+export type scoreType = number & { [scoreSym]: any }
 
 let $parent = atom<scoreType>(1 as scoreType)
 $parent.subscribe(value => {
   value = 1 as scoreType
   return value + 1
 })
+
+let $store4 = atom('')
+let readonlyAtom: ReadableAtom<string> = $store4

--- a/atom/index.d.ts
+++ b/atom/index.d.ts
@@ -81,7 +81,7 @@ export interface ReadableAtom<Value = any> {
    * Low-level method to read store’s value without calling `onStart`.
    *
    * Try to use only {@link ReadableAtom#get}.
-   * Without subscribers, value can de undefined.
+   * Without subscribers, value can be undefined.
    */
   readonly value: undefined | Value
 }
@@ -100,6 +100,11 @@ export interface WritableAtom<Value = any> extends ReadableAtom<Value> {
    * @param newValue New store value.
    */
   set(newValue: Value): void
+}
+
+export interface PreinitializedWritableAtom<Value extends any>
+  extends WritableAtom<Value> {
+  readonly value: Value
 }
 
 export type Atom<Value = any> = ReadableAtom<Value> | WritableAtom<Value>
@@ -136,4 +141,4 @@ export declare let notifyId: number
  */
 export function atom<Value, StoreExt = {}>(
   ...args: undefined extends Value ? [] | [Value] : [Value]
-): StoreExt & WritableAtom<Value>
+): PreinitializedWritableAtom<Value> & StoreExt

--- a/computed/errors.ts
+++ b/computed/errors.ts
@@ -1,0 +1,7 @@
+import { atom } from '../atom/index.js'
+import { computed } from './index.js'
+
+let $word = atom<'a' | 'the'>('a')
+let $length = computed($word, word => word.length)
+// THROWS Type 'number | undefined' is not assignable to type 'number'.
+let length: number = $length.value

--- a/map/errors.ts
+++ b/map/errors.ts
@@ -34,3 +34,6 @@ $test.setKey('a', 'string')
 $test.setKey('b', 5)
 // THROWS Argument of type '"z"' is not assignable to parameter
 $test.setKey('z', '123')
+
+let $preinitialized = map()
+let initialValue: object = $preinitialized.value

--- a/map/index.d.ts
+++ b/map/index.d.ts
@@ -117,6 +117,11 @@ export interface MapStore<Value extends object = any>
   ): () => void
 }
 
+export interface PreinitializedMapStore<Value extends object = any>
+  extends MapStore<Value> {
+  readonly value: Value
+}
+
 /**
  * Create map store. Map store is a store with key-value object
  * as a store value.
@@ -126,4 +131,4 @@ export interface MapStore<Value extends object = any>
  */
 export function map<Value extends object, StoreExt extends object = {}>(
   value?: Value
-): MapStore<Value> & StoreExt
+): PreinitializedMapStore<Value> & StoreExt


### PR DESCRIPTION
This PR improves types for two things:
1. At the moment `atom.value` always includes `undefined` in its type, despite whether initial value was provided or not. So our test usually sprinkled with optional chaining operator (`?.`). This PR changes it and if initial value was specified in atom, then `atom.value` type will be inferred from it and won't have `undefined` in its type.
~~2. If you specify generic type in `map` method as `Record` then `setKey` method won't allow you pass `undefined` as the second parameter and therefore delete item from the map store. It fixes this.~~