### PR TITLE
fix(TS): inferred type cannot be named without reference

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,10 @@
-export { atom, Atom, ReadableAtom, WritableAtom } from './atom/index.js'
+export {
+  atom,
+  Atom,
+  PreinitializedWritableAtom,
+  ReadableAtom,
+  WritableAtom
+} from './atom/index.js'
 export { clean, cleanStores } from './clean-stores/index.js'
 export { batched, computed } from './computed/index.js'
 export {
@@ -27,6 +33,7 @@ export {
   map,
   MapStore,
   MapStoreKeys,
+  PreinitializedMapStore,
   Store,
   StoreValue,
   WritableStore


### PR DESCRIPTION
### Fixes Issue #326

This PR addresses an issue where type inference fails under the following TSconfig settings:

```json
{
    "moduleResolution": "NodeNext",
    "declaration": true
}
```

Since the implementation of #322, the new `Preinitialized` types were not being exported from the module root, causing the type inference to break.

A CodeSandbox example illustrating the issue can be found [here](https://codesandbox.io/p/sandbox/nanostores-typescript-issue-sx4kgm?file=%2Fsrc%2Fnanostores.ts).

**Changes in this PR:**

- Adds the missing exports for Preinitialized types to ensure proper type inference.