### PR TITLE
Add `effect` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ export const Admins = () => {
   - [Deep Maps](#deep-maps)
   - [Lazy Stores](#lazy-stores)
   - [Computed Stores](#computed-stores)
+  - [Effects](#effects)
   - [Tasks](#tasks)
   - [Store Events](#store-events)
 - [Integration](#integration)
@@ -390,6 +391,42 @@ import { $posts } from './posts.js'
 
 export const $newPosts = computed([$lastVisit, $posts], (lastVisit, posts) => {
   return posts.filter(post => post.publishedAt > lastVisit)
+})
+```
+
+
+### Effects
+
+In spite of having ability to use atom's subscribe/notify methods for subscribing on changes, it might be a bit tricky to track changes at multiple atoms at once. `effect` is designed to solve this problem!
+
+`effect` runs its callback on the start, with initial values, as well as on any store(s) change. If callback returns cleanup function it will be performed before next callback run. Besides that, `effect` returns own cleanup function, which allows cancelling the whole effect.
+
+`effect` can be used as analogue of `subscribe` method on one store:
+
+```ts
+import { atom, effect } from 'nanostores'
+
+const $num = atom(10)
+
+effect($atom, num => {
+  console.log(`Number is ${num}`)
+})
+```
+
+`effect` allows easily handle complex cases. This example shows how you can execute any method with specific interval and only when it is enabled. Both `$isEnabled` and `$interval` are atoms and their values can be changed. Whenever it happens it clears interval from the previous run.
+
+```js
+import { sendPing } from '~/api'
+
+const $isEnabled = atom(true)
+const $interval = atom(1000)
+
+const cancelPing = effect([$isEnabled, $interval], (isEnabled, interval) => {
+  if (!isEnabled) return
+
+  const intervalId = setInterval(() => sendPing(), interval)
+
+  return () => clearInterval(intervalId)
 })
 ```
 

--- a/effect/errors.ts
+++ b/effect/errors.ts
@@ -1,0 +1,12 @@
+import { atom } from '../atom/index.js'
+import { effect } from './index.js'
+
+let $first = atom('Tony')
+let $last = atom('Stark')
+let $age = atom(38)
+
+effect([$first, $last, $age], (first, last, age) => {
+  let firstStr: string = first
+  let lastStr: string = last
+  let ageNum: number = age
+})

--- a/effect/index.d.ts
+++ b/effect/index.d.ts
@@ -1,0 +1,33 @@
+import type { StoreValues } from '../computed/index.d.ts'
+import type { AnyStore, Store, StoreValue } from '../index.js'
+
+interface Effect {
+  <OriginStore extends Store>(
+    stores: OriginStore,
+    cb: (value: StoreValue<OriginStore>) => void | VoidFunction
+  ): VoidFunction
+  /**
+   *
+   * Create effect, which subscribes to all stores and runs callback with their values on change in any of them.
+   * Especially useful for side effects which must cleanup after themselves.
+   *
+   * ```js
+   * const $isEnabled = atom(true)
+   * const $interval = atom(1000)
+   *
+   * const cancelPing = effect([$isEnabled, $interval], (isEnabled, interval) => {
+   *   if (!isEnabled) return
+   *
+   *   const intervalId = setInterval(() => sendPing(), interval)
+   *
+   *   return () => clearInterval(intervalId)
+   * })
+   * ```
+   */
+  <OriginStores extends AnyStore[]>(
+    stores: [...OriginStores],
+    cb: (...values: StoreValues<OriginStores>) => void | VoidFunction
+  ): VoidFunction
+}
+
+export const effect: Effect

--- a/effect/index.js
+++ b/effect/index.js
@@ -1,0 +1,21 @@
+export let effect = (stores, callback) => {
+  if (!Array.isArray(stores)) stores = [stores]
+
+  let unbinds = []
+  let lastRunUnbind
+
+  let run = () => {
+    lastRunUnbind && lastRunUnbind()
+
+    let values = stores.map(store => store.get())
+    lastRunUnbind = callback(...values)
+  }
+
+  unbinds = stores.map(store => store.listen(run))
+  run()
+
+  return () => {
+    unbinds.forEach(unbind => unbind())
+    lastRunUnbind && lastRunUnbind()
+  }
+}

--- a/effect/index.test.ts
+++ b/effect/index.test.ts
@@ -1,0 +1,87 @@
+import { strictEqual } from 'node:assert'
+import type { Mock, TestContext } from 'node:test'
+import { test } from 'node:test'
+
+import type { WritableAtom } from '../atom/index.js'
+import { atom } from '../atom/index.js'
+import { effect } from './index.js'
+
+function createTestData(ctx: TestContext): {
+  $atom1: WritableAtom<number>
+  $atom2: WritableAtom<number>
+  $atom3: WritableAtom<number>
+  atomsSumRef: { current: number }
+  effectCleanupMock: Mock<VoidFunction>
+  runsRef: { current: number }
+  unbind: VoidFunction
+} {
+  let runsRef = { current: 0 }
+  let atomsSumRef = { current: 0 }
+
+  let $atom1 = atom(1)
+  let $atom2 = atom(2)
+  let $atom3 = atom(3)
+  let effectCleanupMock = ctx.mock.fn()
+
+  function effectFn(
+    value1: number,
+    value2: number,
+    value3: number
+  ): VoidFunction {
+    runsRef.current += 1
+    atomsSumRef.current = value1 + value2 + value3
+
+    return effectCleanupMock
+  }
+
+  let unbind = effect([$atom1, $atom2, $atom3], effectFn)
+
+  return {
+    $atom1,
+    $atom2,
+    $atom3,
+    atomsSumRef,
+    effectCleanupMock,
+    runsRef,
+    unbind
+  }
+}
+
+test('Runs effect on the initial call with the proper atom values', ctx => {
+  let { atomsSumRef, runsRef } = createTestData(ctx)
+
+  strictEqual(runsRef.current, 1)
+  strictEqual(atomsSumRef.current, 6)
+})
+
+test('Updates value on any atom change', ctx => {
+  let { $atom1, $atom2, $atom3, atomsSumRef, runsRef } = createTestData(ctx)
+
+  $atom1.set(5)
+  strictEqual(runsRef.current, 2)
+  strictEqual(atomsSumRef.current, 10)
+  $atom2.set(10)
+  strictEqual(runsRef.current, 3)
+  strictEqual(atomsSumRef.current, 18)
+  $atom3.set(15)
+  strictEqual(runsRef.current, 4)
+  strictEqual(atomsSumRef.current, 30)
+})
+
+test('Calls cleanup function before each run', ctx => {
+  let { $atom1, effectCleanupMock } = createTestData(ctx)
+
+  $atom1.set(10)
+  strictEqual(effectCleanupMock.mock.calls.length, 1)
+  $atom1.set(20)
+  strictEqual(effectCleanupMock.mock.calls.length, 2)
+})
+
+test('Stops running effect when returned unsubscribe method called. Runs effect cleanup as well', ctx => {
+  let { $atom1, effectCleanupMock, unbind } = createTestData(ctx)
+
+  unbind()
+  strictEqual(effectCleanupMock.mock.calls.length, 1)
+  $atom1.set(30)
+  strictEqual(effectCleanupMock.mock.calls.length, 1)
+})

--- a/index.d.ts
+++ b/index.d.ts
@@ -17,6 +17,7 @@ export {
   setByKey,
   setPath
 } from './deep-map/index.js'
+export { effect } from './effect/index.js'
 export { keepMount } from './keep-mount/index.js'
 export {
   onMount,

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ export { atom } from './atom/index.js'
 export { clean, cleanStores } from './clean-stores/index.js'
 export { batched, computed } from './computed/index.js'
 export { deepMap, getPath, setByKey, setPath } from './deep-map/index.js'
+export { effect } from './effect/index.js'
 export { keepMount } from './keep-mount/index.js'
 export {
   onMount,


### PR DESCRIPTION
# Motivation

In spite of having ability to use atom's subscribe/notify methods for subscribing on changes, it might be a bit tricky to track changes at multiple atoms at once. `effect` is designed to solve this problem! And it is similar to the `effect` method from other state managers (like Solid's signals, or state manager in Svelte)

# How it works

`effect` runs its callback on the start, with initial values, as well as on any store(s) change. If callback returns cleanup function it will be performed before next callback run. Besides that, `effect` returns own cleanup function, which allows cancelling the whole effect.

# Usages

`effect` can be used as analogue of `subscribe` method on one store:

```ts
import { atom, effect } from 'nanostores'

const $num = atom(10)

effect($atom, num => {
  console.log(`Number is ${num}`)
})
```

`effect` allows easily handle complex cases. This example shows how we can create resize observer atom, which will create [ResizeObserver](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver) instance based on passed element and options (which can be changes outside, since they are both atoms). Whenever element or options are changed it re-runs effect and cleans up ResizeObserver instance for the previous effect run.

```ts
import { atom, effect, onMount, type ReadableAtom } from 'nanostores'

type ResizeObserverAtomOptions<E extends HTMLElement, Mapped> = {
  $element: ReadableAtom<E | null>
  $observerOptions?: ReadableAtom<ResizeObserverOptions>
  initialValue: Mapped
  mapper: (entry: ResizeObserverEntry) => Mapped
}

export function createResizeObserverAtom<E extends HTMLElement, Mapped>({
  $element,
  $observerOptions,
  initialValue,
  mapper
}: ResizeObserverAtomOptions<E, Mapped>) {
  const $result = atom(initialValue)

  onMount($result, () => {
    // Notice how we use returned cleanup function as returned function from onMount
    // It will automatically stop effect when $result no longer has any subscribers,
    // and cleanup everything
    return effect([$element, $observerOptions], (element, observerOptions) => {
      if (!element) {
        return
      }

      const resizeObserver = new ResizeObserver(entries => {
        const entry = entries[0]

        if (entry) {
          $result.set(mapper(entry))
        }
      })
      resizeObserver.observe(element, observerOptions)

      return () => resizeObserver.disconnect()
    })
  })

  return $result
}
```
