### PR TITLE
Explicitly allow undefined as setKey input

### DIFF
--- a/map/index.d.ts
+++ b/map/index.d.ts
@@ -97,7 +97,7 @@ export interface MapStore<Value extends object = any>
    */
   setKey<Key extends AllKeys<Value>>(
     key: Key,
-    value: Get<Value, Key> | Value[Key]
+    value: Get<Value, Key> | Value[Key] | undefined
   ): void
 
   /**


### PR DESCRIPTION
In TypeScript, allows `undefined` as input to `map.setKey` as documented.

>    To delete key set `undefined`.
>    
>    ```js
>    $settings.setKey('theme', undefined)
>    ```