### PR TITLE
fix(typescript): subscribeKeys listener missing oldValue

### DIFF
--- a/listen-keys/index.d.ts
+++ b/listen-keys/index.d.ts
@@ -65,6 +65,7 @@ export function subscribeKeys<
     : never,
   listener: (
     value: StoreValue<SomeStore>,
+    oldValue: StoreValue<SomeStore>,
     changed: SomeStore extends {
       setKey: (key: infer Key, value: never) => unknown
     }


### PR DESCRIPTION
The typings for the subscribeKeys listener was missing the oldValue.

Fixes #348