### PR TITLE
Allow undefined for map and deepmap

### DIFF
--- a/deep-map/errors.ts
+++ b/deep-map/errors.ts
@@ -4,9 +4,9 @@ type TestType =
   | { id: string; isLoading: true }
   | { isLoading: false; a: { b: number; c: string[] } }
 
-let test = deepMap<TestType>()
+let $test = deepMap<TestType>()
 
-test.subscribe((_, __, changedKey) => {
+$test.subscribe((_, __, changedKey) => {
   if (changedKey === 'a') {
   }
   // THROWS have no overlap
@@ -14,7 +14,7 @@ test.subscribe((_, __, changedKey) => {
   }
 })
 
-test.listen((_, __, changedKey) => {
+$test.listen((_, __, changedKey) => {
   if (changedKey === 'a') {
   }
   // THROWS have no overlap
@@ -22,17 +22,43 @@ test.listen((_, __, changedKey) => {
   }
 })
 
-test.setKey('isLoading', true)
-test.setKey('id', '123')
-test.setKey('a', { b: 1, c: [] })
-test.setKey('a.b', 123)
-test.setKey('a.c', [''])
-test.setKey('a.c[3]', '123')
+$test.setKey('isLoading', true)
+$test.setKey('id', '123')
+$test.setKey('a', { b: 1, c: [] })
+$test.setKey('a.b', 123)
+$test.setKey('a.c', [''])
+$test.setKey('a.c[3]', '123')
 // THROWS Argument of type 'number' is not assignable to parameter
-test.setKey('a.c[3]', 123)
+$test.setKey('a.c[3]', 123)
 // THROWS Argument of type '"z"' is not assignable to parameter
-test.setKey('z', '123')
+$test.setKey('z', '123')
 
-test.setKey('isLoading', false)
+$test.setKey('isLoading', false)
 // THROWS Argument of type '"z"' is not assignable to parameter
-test.setKey('z', '123')
+$test.setKey('z', '123')
+
+let $test2 = deepMap<TestType | undefined>({ id: '123', isLoading: true })
+$test2.set(undefined)
+// THROWS Argument of type 'undefined' is not assignable to parameter of type 'TestType'
+$test.set(undefined)
+
+// THROWS Argument of type 'string' is not assignable to parameter of type 'boolean'
+$test2.setKey('isLoading', 'banana')
+
+// Subscribe picks up the undefined type of the store
+$test2.subscribe(value => {
+  // THROWS 'value' is possibly 'undefined'
+  value.isLoading
+})
+
+$test2.setKey('a.c[3]', '123')
+// THROWS Argument of type 'number' is not assignable to parameter
+$test2.setKey('a.c[3]', 123)
+
+// THROWS Argument of type undefined is not assignable to parameter of type 'Record<string, unknown>'.
+let $test3 = deepMap<Record<string, unknown>>(undefined) // Currently doesn't throw
+// THROWS Expected 1 arguments, but got 0
+let $test4 = deepMap<Record<string, unknown>>() // Currently doesn't throw
+
+let $test5 = deepMap<Record<string, unknown> | undefined>()
+let $test6 = deepMap<Record<string, unknown> | undefined>(undefined)

--- a/deep-map/index.d.ts
+++ b/deep-map/index.d.ts
@@ -1,9 +1,16 @@
 import type { WritableAtom } from '../atom/index.js'
 import type { AllPaths, BaseDeepMap, FromPath } from './path.js'
 
-export { AllPaths, BaseDeepMap, FromPath, getPath, setByKey, setPath } from './path.js'
+export {
+  AllPaths,
+  BaseDeepMap,
+  FromPath,
+  getPath,
+  setByKey,
+  setPath
+} from './path.js'
 
-export type DeepMapStore<T extends BaseDeepMap> = {
+export type DeepMapStore<T extends BaseDeepMap | undefined> = {
   /**
    * Subscribe to store changes.
    *
@@ -78,4 +85,6 @@ export type DeepMapStore<T extends BaseDeepMap> = {
  * @param init Initialize store and return store destructor.
  * @returns The store object with methods to subscribe.
  */
-export function deepMap<T extends BaseDeepMap>(init?: T): DeepMapStore<T>
+export function deepMap<Value extends BaseDeepMap | undefined>(
+  value?: Value
+): DeepMapStore<Value>

--- a/deep-map/index.js
+++ b/deep-map/index.js
@@ -3,12 +3,12 @@ import { getPath, setPath } from './path.js'
 
 export { getPath, setByKey, setPath } from './path.js'
 
-export function deepMap(initial = {}) {
+export function deepMap(initial) {
   let $deepMap = atom(initial)
   $deepMap.setKey = (key, value) => {
-    if (getPath($deepMap.value, key) !== value) {
+    if (getPath($deepMap.value ?? {}, key) !== value) {
       let oldValue = $deepMap.value
-      $deepMap.value = setPath($deepMap.value, key, value)
+      $deepMap.value = setPath($deepMap.value ?? {}, key, value)
       $deepMap.notify(oldValue, key)
     }
   }

--- a/deep-map/index.test.ts
+++ b/deep-map/index.test.ts
@@ -400,3 +400,31 @@ test('keys starting with numbers do not create unnecessary arrays', () => {
   $store.setKey('key.100key', 'value')
   deepStrictEqual($store.get(), { key: { '100key': 'value' } })
 })
+
+test('initializing without a ', () => {
+  let events: ({ a: number } | undefined)[] = []
+  let $store = deepMap<{ a: number } | undefined>()
+  let unbind = $store.listen((value, oldValue) => {
+    events.push(oldValue)
+  })
+  equal($store.get(), undefined)
+  $store.setKey('a', 1)
+  $store.setKey('a', 2)
+  deepStrictEqual(events, [undefined, { a: 1 }])
+  unbind()
+  clock.runAll()
+})
+
+test('setKey works on undefined values', () => {
+  let events: ({ a: number } | undefined)[] = []
+  let $store = deepMap<{ a: number } | undefined>()
+  let unbind = $store.listen((value, oldValue) => {
+    events.push(oldValue)
+  })
+  equal($store.get(), undefined)
+  $store.setKey('a', 1)
+  $store.setKey('a', 2)
+  deepStrictEqual(events, [undefined, { a: 1 }])
+  unbind()
+  clock.runAll()
+})

--- a/map/errors.ts
+++ b/map/errors.ts
@@ -42,4 +42,26 @@ $testIndexSignature.setKey('a', 1)
 $testIndexSignature.setKey('a', undefined)
 
 let $preinitialized = map()
-let initialValue: object = $preinitialized.value
+let initialValue: object | undefined = $preinitialized.value
+
+let $test2 = map<TestType | undefined>({ id: '123', isLoading: true })
+$test2.set(undefined)
+// THROWS Argument of type 'undefined' is not assignable to parameter of type 'TestType'
+$test.set(undefined)
+
+// THROWS Argument of type 'string' is not assignable to parameter of type 'boolean'
+$test2.setKey('isLoading', 'banana')
+
+// Subscribe picks up the undefined type of the store
+$test2.subscribe(value => {
+  // THROWS 'value' is possibly 'undefined'
+  value.isLoading
+})
+
+// THROWS Argument of type undefined is not assignable to parameter of type 'Record<string, unknown>'.
+let $test3 = map<Record<string, unknown>>(undefined) // Currently doesn't throw
+// THROWS Expected 1 arguments, but got 0
+let $test4 = map<Record<string, unknown>>() // Currently doesn't throw
+
+let $test5 = map<Record<string, unknown> | undefined>()
+let $test6 = map<Record<string, unknown> | undefined>(undefined)

--- a/map/index.d.ts
+++ b/map/index.d.ts
@@ -43,7 +43,8 @@ export type MapStoreKeys<SomeStore> = SomeStore extends {
   ? K
   : AllKeys<StoreValue<SomeStore>>
 
-export interface MapStore<Value extends object = any>
+export type MapValue<Value> = Exclude<undefined, Value>
+export interface MapStore<Value extends object | undefined = any>
   extends WritableAtom<Value> {
   /**
    * Subscribe to store changes.
@@ -102,9 +103,11 @@ export interface MapStore<Value extends object = any>
    * @param key The key name.
    * @param value New value.
    */
-  setKey<Key extends AllKeys<Value>>(
+  setKey<Key extends AllKeys<Exclude<Value, undefined>>>(
     key: Key,
-    value: Get<Value, Key> | ValueWithUndefinedForIndexSignatures<Value, Key>
+    value:
+      | Get<Exclude<Value, undefined>, Key>
+      | ValueWithUndefinedForIndexSignatures<Exclude<Value, undefined>, Key>
   ): void
 
   /**
@@ -127,12 +130,12 @@ export interface MapStore<Value extends object = any>
     listener: (
       value: ReadonlyIfObject<Value>,
       oldValue: ReadonlyIfObject<Value> | undefined,
-      changedKey: AllKeys<Value> | undefined
+      changedKey: AllKeys<Exclude<Value, undefined>> | undefined
     ) => void
   ): () => void
 }
 
-export interface PreinitializedMapStore<Value extends object = any>
+export interface PreinitializedMapStore<Value extends object | undefined = any>
   extends MapStore<Value> {
   readonly value: Value
 }
@@ -144,6 +147,8 @@ export interface PreinitializedMapStore<Value extends object = any>
  * @param init Initialize store and return store destructor.
  * @returns The store object with methods to subscribe.
  */
-export function map<Value extends object, StoreExt extends object = object>(
-  value?: Value
-): PreinitializedMapStore<Value> & StoreExt
+
+export function map<
+  Value extends object | undefined,
+  StoreExt extends object = object
+>(value?: Value): PreinitializedMapStore<Value> & StoreExt

--- a/map/index.js
+++ b/map/index.js
@@ -1,15 +1,15 @@
 import { atom } from '../atom/index.js'
 
-export let map = (initial = {}) => {
+export let map = initial => {
   let $map = atom(initial)
 
   $map.setKey = function (key, value) {
     let oldMap = $map.value
-    if (typeof value === 'undefined' && key in $map.value) {
+    if (typeof value === 'undefined' && key in ($map.value ?? {})) {
       $map.value = { ...$map.value }
       delete $map.value[key]
       $map.notify(oldMap, key)
-    } else if ($map.value[key] !== value) {
+    } else if (($map.value ?? {})[key] !== value) {
       $map.value = {
         ...$map.value,
         [key]: value

--- a/map/index.test.ts
+++ b/map/index.test.ts
@@ -349,3 +349,17 @@ test('can use previous value in subscribers', () => {
   unbind()
   clock.runAll()
 })
+
+test('setKey works on undefined values', () => {
+  let events: ({ a: number } | undefined)[] = []
+  let $store = map<{ a: number } | undefined>(undefined)
+  let unbind = $store.listen((value, oldValue) => {
+    events.push(oldValue)
+  })
+  equal($store.get(), undefined)
+  $store.setKey('a', 1)
+  $store.setKey('a', 2)
+  deepStrictEqual(events, [undefined, { a: 1 }])
+  unbind()
+  clock.runAll()
+})

--- a/package.json
+++ b/package.json
@@ -93,10 +93,11 @@
       "import": {
         "./index.js": "{ map, computed }"
       },
-      "limit": "801 B"
+      "limit": "804 B"
     }
   ],
   "clean-publish": {
     "cleanDocs": true
-  }
+  },
+  "packageManager": "pnpm@10.5.2+sha512.da9dc28cd3ff40d0592188235ab25d3202add8a207afbedc682220e4a0029ffbff4562102b9e6e46b4e3f9e8bd53e6d05de48544b0c57d4b0179e22c76d1199b"
 }

--- a/package.json
+++ b/package.json
@@ -98,6 +98,5 @@
   ],
   "clean-publish": {
     "cleanDocs": true
-  },
-  "packageManager": "pnpm@10.5.2+sha512.da9dc28cd3ff40d0592188235ab25d3202add8a207afbedc682220e4a0029ffbff4562102b9e6e46b4e3f9e8bd53e6d05de48544b0c57d4b0179e22c76d1199b"
+  }
 }


### PR DESCRIPTION
Allows undefined values for `map()` and `deepMap()`.

Has a known type issue