### PR TITLE
Allow setKey undefined on string indexed maps

### DIFF
--- a/map/errors.ts
+++ b/map/errors.ts
@@ -37,5 +37,9 @@ $test.setKey('b', 5)
 // THROWS Argument of type '"z"' is not assignable to parameter
 $test.setKey('z', '123')
 
+let $testIndexSignature = map<Record<string, number>>()
+$testIndexSignature.setKey('a', 1)
+$testIndexSignature.setKey('a', undefined)
+
 let $preinitialized = map()
 let initialValue: object = $preinitialized.value

--- a/map/index.d.ts
+++ b/map/index.d.ts
@@ -9,6 +9,13 @@ type KeyofBase = keyof any
 
 type Get<T, K extends KeyofBase> = Extract<T, { [K1 in K]: any }>[K]
 
+export type HasIndexSignature<T> = string extends keyof T ? true : false
+
+export type ValueWithUndefinedForIndexSignatures<
+  Value,
+  Key extends keyof Value
+> = HasIndexSignature<Value> extends true ? undefined | Value[Key] : Value[Key]
+
 export type WritableStore<Value = any> =
   | (Value extends object ? MapStore<Value> : never)
   | WritableAtom<Value>
@@ -97,7 +104,7 @@ export interface MapStore<Value extends object = any>
    */
   setKey<Key extends AllKeys<Value>>(
     key: Key,
-    value: Get<Value, Key> | Value[Key]
+    value: Get<Value, Key> | ValueWithUndefinedForIndexSignatures<Value, Key>
   ): void
 
   /**


### PR DESCRIPTION
The most asked question I've seen for this package is about the behavior of `setKey` on maps, when it comes to `undefined`. For string-indexed maps that don't explicitly allow undefined, users need to use type assertions to delete items. (For example, check out [this question](https://github.com/orgs/nanostores/discussions/353#discussioncomment-12338911)).

This behavior doesn’t really match how TypeScript handles string-indexed maps. While I think Nanostores current approach is technically more correct than TypeScript, it’s clearly not the behavior users expect (And it would break too many repos for TS to change it's default behavior, see [this discussion](https://github.com/microsoft/TypeScript/issues/49169)).

Therefore I came up with a solution where we can check if the Map is string indexed, and in that case allow deletion using undefined. 

Right now, this PR is just a discussion. If we decide this is the direction to go, I’ll also need to add a similar change to the `deepMap`.