### PR TITLE
Allow set key undefined on string indexed deepMap

### DIFF
--- a/deep-map/errors.ts
+++ b/deep-map/errors.ts
@@ -36,3 +36,44 @@ test.setKey('z', '123')
 test.setKey('isLoading', false)
 // THROWS Argument of type '"z"' is not assignable to parameter
 test.setKey('z', '123')
+
+type TestTypeIndexSignature = {
+  id: string
+  isRecord: Record<string, number>
+  isArray: Array<TestType>
+}
+
+let $testIndexSignature = deepMap<Record<string, Record<string, number>>>()
+let $testIndexSignature2 = deepMap<Record<string, TestType>>()
+let $testIndexSignature3 = deepMap<Record<string, TestTypeIndexSignature>>()
+
+$testIndexSignature.setKey('a', undefined)
+$testIndexSignature2.setKey('a', undefined)
+// THROWS Argument of type 'undefined' is not assignable to parameter
+test.setKey('a', undefined)
+$testIndexSignature.setKey('a.b', undefined)
+$testIndexSignature.setKey('a.b', 1)
+// THROWS Argument of type 'string' is not assignable to parameter
+$testIndexSignature.setKey('a.b', 'hej')
+// THROWS Argument of type 'undefined' is not assignable to parameter
+$testIndexSignature2.setKey('a.isLoading', undefined)
+// THROWS Argument of type 'string' is not assignable to parameter
+$testIndexSignature2.setKey('a.isLoading', 'incorrect')
+
+$testIndexSignature3.setKey('a.isRecord', {})
+$testIndexSignature3.setKey('a.isRecord.b', 1)
+// THROWS Argument of type 'string' is not assignable to parameter
+$testIndexSignature3.setKey('a.isRecord.b', 'hej')
+
+$testIndexSignature3.setKey('a.isArray', [])
+$testIndexSignature3.setKey('a.isArray[0]', {
+  id: '123',
+  isLoading: true
+})
+// THROWS Argument of type '{ id: string; }' is not assignable to parameter
+$testIndexSignature3.setKey('a.isArray[0]', {
+  id: '123'
+})
+$testIndexSignature3.setKey('a.isArray[0].id', '123')
+// THROWS Argument of type 'number' is not assignable to parameter
+$testIndexSignature3.setKey('a.isArray[0].id', 123)

--- a/deep-map/index.d.ts
+++ b/deep-map/index.d.ts
@@ -1,7 +1,18 @@
 import type { WritableAtom } from '../atom/index.js'
-import type { AllPaths, BaseDeepMap, FromPath } from './path.js'
+import type {
+  AllPaths,
+  BaseDeepMap,
+  FromPathWithIndexSignatureUndefined
+} from './path.js'
 
-export { AllPaths, BaseDeepMap, FromPath, getPath, setByKey, setPath } from './path.js'
+export {
+  AllPaths,
+  BaseDeepMap,
+  FromPath,
+  getPath,
+  setByKey,
+  setPath
+} from './path.js'
 
 export type DeepMapStore<T extends BaseDeepMap> = {
   /**
@@ -44,7 +55,10 @@ export type DeepMapStore<T extends BaseDeepMap> = {
    * @param key The key name. Attributes can be split with a dot `.` and `[]`.
    * @param value New value.
    */
-  setKey: <K extends AllPaths<T>>(key: K, value: FromPath<T, K>) => void
+  setKey: <K extends AllPaths<T>>(
+    key: K,
+    value: FromPathWithIndexSignatureUndefined<T, K>
+  ) => void
 
   /**
    * Subscribe to store changes and call listener immediately.


### PR DESCRIPTION
Following up on #358, this PR adds typings for `deepMap`. I haven't used `deepMap`, so there might be some edge cases I've missed, but all of the changes are to the types.

The typings for the deep pathing is complicated, and it essentially forced me to duplicate the types that were affected. I also tried adding thorough type tests (Root level indexed, lower level indexed, making sure the base case was not affected), but if there are any cases that I didn't test I'd gladly add that.