### PR TITLE
fix(map-creator): update the type for the record key

### DIFF
--- a/map-creator/index.d.ts
+++ b/map-creator/index.d.ts
@@ -19,7 +19,7 @@ export interface MapCreator<
 export function mapCreator<
   Value extends object,
   Args extends any[] = [],
-  StoreExt = Record<unknown, any>
+  StoreExt = Record<number | string | symbol, any>
 >(
   init?: (
     store: MapStore<{ id: string } & Value> & StoreExt,


### PR DESCRIPTION
I have updated the map-creator Record type to have a key of `number | string | symbol` instead of  `unknown`.

Why? When `skipLibCheck` is disabled (either set to false or not included at all), the TypeScript compiler will display the following:

> node_modules/nanostores/map-creator/index.d.ts:22:21 - error TS2344: Type 'unknown' does not satisfy
> the constraint 'string | number | symbol'.
> 
> 22   StoreExt = Record<unknown, any>