### PR TITLE
Add Immer plugin to list of related projects in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,8 @@ npm install nanostores
   remote data fetching.
 * [Logux Client](https://github.com/logux/client): stores with WebSocket
   sync and CRDT conflict resolution.
+* [Immer](https://github.com/illuxiza/nanostores-immer) plugin to
+  enable immutable state updates using Immer.
 
 
 ## Devtools


### PR DESCRIPTION
This PR updates the **Smart Stores** section of `README.md` by introducing a new entry:

> **Nanostores Immer** (`https://github.com/illuxiza/nanostores-immer`):
> A plugin that integrates [Immer](https://immerjs.github.io/immer/) with Nanostores, enabling immutable state updates via a familiar, mutable-style API.

## Changes

- **README.md**
  - Added a bullet under **Smart Stores** linking to the `nanostores-immer` repository.
  - Briefly described its purpose and functionality.