### PR TITLE
fix(computed): detect signed-zero dependency changes

### DIFF
--- a/computed/index.js
+++ b/computed/index.js
@@ -12,7 +12,7 @@ let computedStore = (stores, cb, batched) => {
     if (currentEpoch === nanostoresGlobal.epoch) return
     currentEpoch = nanostoresGlobal.epoch
     let args = stores.map($store => $store.get())
-    if (!previousArgs || args.some((arg, i) => !Object.is(arg, previousArgs[i]))) {
+    if (!previousArgs?.every((arg, i) => stores[i].eq(arg, args[i]))) {
       previousArgs = args
       let value = cb(...args)
       if (value && value.then && value.t) {

--- a/computed/index.js
+++ b/computed/index.js
@@ -12,7 +12,7 @@ let computedStore = (stores, cb, batched) => {
     if (currentEpoch === nanostoresGlobal.epoch) return
     currentEpoch = nanostoresGlobal.epoch
     let args = stores.map($store => $store.get())
-    if (!previousArgs || args.some((arg, i) => arg !== previousArgs[i])) {
+    if (!previousArgs || args.some((arg, i) => !Object.is(arg, previousArgs[i]))) {
       previousArgs = args
       let value = cb(...args)
       if (value && value.then && value.t) {
@@ -33,7 +33,7 @@ let computedStore = (stores, cb, batched) => {
       }
     }
   }
-  let $computed = atom(undefined)
+  let $computed = atom()
   let get = $computed.get
   $computed.get = () => {
     set()

--- a/computed/index.test.ts
+++ b/computed/index.test.ts
@@ -713,3 +713,24 @@ test('recomputes when an atom changes between signed zero values', () => {
 
   unbind()
 })
+
+test('uses the dependency equality function', () => {
+  let $source = map({ count: 1, metadata: 'first' })
+  $source.eq = (oldValue, newValue) => oldValue?.count === newValue.count
+  let runs = 0
+  let $count = computed($source, value => {
+    runs += 1
+    return value.count
+  })
+
+  let unbind = $count.subscribe(() => {})
+  equal(runs, 1)
+
+  $source.setKey('metadata', 'second')
+  equal(runs, 1)
+
+  $source.setKey('count', 2)
+  equal(runs, 2)
+
+  unbind()
+})

--- a/computed/index.test.ts
+++ b/computed/index.test.ts
@@ -698,3 +698,18 @@ test('passes undefined as old value on the first computed run', () => {
   equal($double.get(), 6)
   deepStrictEqual(oldValues, [undefined, 2])
 })
+
+test('recomputes when an atom changes between signed zero values', () => {
+  let $source = atom(-0)
+  let $reciprocal = computed($source, value => 1 / value)
+  let values: number[] = []
+
+  let unbind = $reciprocal.subscribe(value => {
+    values.push(value)
+  })
+
+  $source.set(0)
+  deepStrictEqual(values, [-Infinity, Infinity])
+
+  unbind()
+})


### PR DESCRIPTION
## Problem

A computed store can remain stale when an atom changes from `-0` to `0`. The atom correctly treats those values as different, but the computed dependency cache compares them with `!==`, so a derived value such as `1 / value` remains `-Infinity` instead of becoming `Infinity`.

## Fix

Compare cached dependency values through each source store's `eq(oldValue, newValue)` function. Its default `Object.is` behavior detects signed-zero changes, while custom equality functions remain effective for computed dependencies. The `every()` form keeps the enforced Popular Set size at its 912 B budget.

## Tests

- `pnpm bnt -t 'signed zero' computed/index.test.ts` — passed
- `pnpm bnt -t 'dependency equality function' computed/index.test.ts` — failed before the follow-up and passed after it
- `pnpm bnt computed/index.test.ts atom/index.test.ts` — passed
- `pnpm test` — passed; 60 tests, full coverage/lint/types/sync checks, Popular Set 912 B / 912 B
- `pnpm exec oxlint computed/index.js computed/index.test.ts` — passed
- `git diff --check` — passed

## Compatibility

This aligns computed dependency caching with the source store's existing equality contract. The default behavior changes only the signed-zero edge case; stores that replace `eq` retain their chosen comparison semantics. No package manifest, lockfile, or public signature changed.

## Related issue

Independent reproduction; no issue linked.
