### PR TITLE
Fix batch() inside a listener replaying listeners that already ran

### DIFF
--- a/atom/index.js
+++ b/atom/index.js
@@ -10,24 +10,25 @@ const QUEUE_ITEMS_PER_LISTENER = 4
 // from React), causing each bundle to have its own epoch instance.
 export const nanostoresGlobal = (globalThis.nanostoresGlobal ||= { epoch: 0 })
 
+// Advance lqIndex before calling a listener: batch() re-enters drainQueue
+// from its finally block, and the nested drain must resume, not replay.
 let drainQueue = () => {
   let thrown
-  for (
-    lqIndex = 0;
-    lqIndex < listenerQueue.length;
+  let i
+  while (lqIndex < listenerQueue.length) {
+    i = lqIndex
     lqIndex += QUEUE_ITEMS_PER_LISTENER
-  ) {
     try {
-      listenerQueue[lqIndex](
-        listenerQueue[lqIndex + 1].value,
-        listenerQueue[lqIndex + 2],
-        listenerQueue[lqIndex + 3]
+      listenerQueue[i](
+        listenerQueue[i + 1].value,
+        listenerQueue[i + 2],
+        listenerQueue[i + 3]
       )
     } catch (e) {
       thrown = e
     }
   }
-  listenerQueue.length = 0
+  listenerQueue.length = lqIndex = 0
   if (thrown) throw thrown
 }
 
@@ -64,10 +65,7 @@ export const atom = initialValue => {
       $atom.lc = listeners.push(listener)
 
       return () => {
-        for (
-          let i = lqIndex + QUEUE_ITEMS_PER_LISTENER;
-          i < listenerQueue.length;
-        ) {
+        for (let i = lqIndex; i < listenerQueue.length; ) {
           if (listenerQueue[i] === listener) {
             listenerQueue.splice(i, QUEUE_ITEMS_PER_LISTENER)
           } else {

--- a/atom/index.test.ts
+++ b/atom/index.test.ts
@@ -571,6 +571,47 @@ test('nested batch flushes only at the outermost exit', () => {
   unbind()
 })
 
+test('batch inside a listener does not replay listeners already run', () => {
+  let $a = atom(0)
+  let $other = atom(0)
+  let log: string[] = []
+  let unbindFirst = $a.listen(value => {
+    log.push(`first:${value}`)
+    batch(() => {
+      $other.set(value)
+    })
+  })
+  let unbindSecond = $a.listen(value => {
+    log.push(`second:${value}`)
+  })
+
+  $a.set(1)
+
+  deepStrictEqual(log, ['first:1', 'second:1'])
+
+  unbindFirst()
+  unbindSecond()
+})
+
+test('empty batch inside a listener does not replay listeners already run', () => {
+  let $a = atom(0)
+  let log: string[] = []
+  let unbindFirst = $a.listen(value => {
+    log.push(`first:${value}`)
+    batch(() => {})
+  })
+  let unbindSecond = $a.listen(value => {
+    log.push(`second:${value}`)
+  })
+
+  $a.set(1)
+
+  deepStrictEqual(log, ['first:1', 'second:1'])
+
+  unbindFirst()
+  unbindSecond()
+})
+
 test('batch outside any listener is identical to a single set', () => {
   let $a = atom(0)
   let log: number[] = []


### PR DESCRIPTION
`batch()` called from inside a listener re-runs listeners that already ran in the same flush:

```js
let $a = atom(0)
$a.listen(() => { log.push('A'); batch(() => {}) })
$a.listen(() => log.push('B'))
$a.set(1) // log is A,A,B; README's Batching section promises A,B
```

`drainQueue()` resets the module-level `lqIndex` to 0 on entry, and `batch()`'s `finally` re-enters it while the outer drain is still walking the queue, so the nested drain starts over.

Fix: advance `lqIndex` past an entry before invoking its listener and reset it only after the queue drains, so a nested drain resumes where the outer one stopped. The unsubscribe scan in `listen()` starts at `lqIndex` to match. Atom bundle 368 B (limit 372 B).

`pnpm test` passes, both new tests fail on current main.

Found with an automated review tool I run; the patch was reviewed and verified by hand.
