### PR TITLE
Make the unbind returned by lifecycle on() idempotent

### DIFF
--- a/lifecycle/index.js
+++ b/lifecycle/index.js
@@ -21,14 +21,16 @@ export let on = (object, listener, eventKey, mutateStore) => {
   }
   object.events[eventKey] = object.events[eventKey] || []
   object.events[eventKey].push(listener)
+  // A second unbind call must be a no-op, as it is for atom's listen()
   return () => {
     let currentListeners = object.events[eventKey]
     let index = currentListeners.indexOf(listener)
-    currentListeners.splice(index, 1)
-    if (!currentListeners.length) {
-      delete object.events[eventKey]
-      object.events[eventKey + REVERT_MUTATION]()
-      delete object.events[eventKey + REVERT_MUTATION]
+    if (~index) {
+      currentListeners.splice(index, 1)
+      if (!currentListeners.length) {
+        object.events[eventKey + REVERT_MUTATION]()
+        delete object.events[eventKey + REVERT_MUTATION]
+      }
     }
   }
 }

--- a/lifecycle/index.test.ts
+++ b/lifecycle/index.test.ts
@@ -43,6 +43,45 @@ test('has onStart and onStop listeners', () => {
   deepStrictEqual(events, ['start', 'stop', 'start', 'stop', 'start'])
 })
 
+test('unbind is a no-op when called more than once', () => {
+  let events: string[] = []
+  let store = atom(0)
+  let unbindFirst = onMount(store, () => {
+    events.push('first')
+  })
+  onMount(store, () => {
+    events.push('second')
+  })
+
+  unbindFirst()
+  unbindFirst()
+  unbindFirst()
+
+  let unbindListen = store.listen(() => {})
+  deepStrictEqual(events, ['second'])
+  unbindListen()
+})
+
+test('re-registering after the last unbind reinstalls the mutation', () => {
+  let events: string[] = []
+  let store = atom(0)
+  let unbindOnly = onStart(store, () => {
+    events.push('start')
+  })
+
+  unbindOnly()
+  unbindOnly()
+
+  let unbindAgain = onStart(store, () => {
+    events.push('again')
+  })
+  let unbindListen = store.listen(() => {})
+  deepStrictEqual(events, ['again'])
+
+  unbindListen()
+  unbindAgain()
+})
+
 test('tracks onStart from listening', () => {
   let events: string[] = []
   let store = atom(2)


### PR DESCRIPTION
The unbind returned by `on()` in `lifecycle/index.js` is not idempotent. A second call gets `indexOf` -1 and `splice(-1, 1)` removes a different listener; once the array has been deleted, a further call throws:

```js
let $s = atom(0)
let unbind = onMount($s, () => log.push('m1'))
onMount($s, () => log.push('m2'))
unbind(); unbind() // removes the m2 listener
unbind()           // TypeError: Cannot read properties of undefined (reading 'indexOf')
```

Atom's own `listen()` unbind already guards with `if (~index)`.

Fix: apply the same guard and keep the emptied array in place, so a later call finds an array and a no-op. Re-registering after the last unbind still reinstalls the mutation (second new test). Popular Set bundle 912 B (limit 912 B).

`pnpm test` passes, both new tests fail on current main.

Found with an automated review tool I run; the patch was reviewed and verified by hand.
