### PR TITLE
fix(task): ignore completions from before cleanup

### DIFF
--- a/task/index.js
+++ b/task/index.js
@@ -1,9 +1,12 @@
 let tasks = 0
+let taskId = 0
 let resolves = []
 
 export function startTask() {
+  let id = taskId
   tasks += 1
   return () => {
+    if (id !== taskId) return
     tasks -= 1
     if (tasks === 0) {
       let prevResolves = resolves
@@ -37,5 +40,6 @@ export function allTasks() {
 }
 
 export function cleanTasks() {
+  taskId += 1
   tasks = 0
 }

--- a/task/index.test.ts
+++ b/task/index.test.ts
@@ -32,6 +32,25 @@ test('waits for nested tasks', async () => {
   equal(track, 'ab')
 })
 
+test('ignores completions from before cleanTasks', async () => {
+  let endOldTask = startTask()
+  cleanTasks()
+
+  let endCurrentTask = startTask()
+  let finished = false
+  let waiting = allTasks().then(() => {
+    finished = true
+  })
+
+  endOldTask()
+  await Promise.resolve()
+  equal(finished, false)
+
+  endCurrentTask()
+  await waiting
+  equal(finished, true)
+})
+
 test('ends task on error', async () => {
   let error = Error('test(')
   let catched: Error | undefined


### PR DESCRIPTION
## Problem

`cleanTasks()` resets the global task count, but completion callbacks created before that reset can still decrement the new count. If a new task starts before an old task finishes, the old completion can make `allTasks()` resolve while the new task is still active.

## Fix

Associate task completions with the current cleanup generation and ignore completions from an earlier generation. The existing behavior within a generation is unchanged.

## Tests

- `pnpm bnt task/index.test.ts` — 6 passed
- `pnpm test` — 62 tests plus lint, types, coverage, size, and synchronized-size checks passed
- `git diff --check` — passed

## Compatibility

The change only affects stale completion callbacks after `cleanTasks()`; current-generation task tracking and the public API remain unchanged.

## Related issue

Independently reproduced on `main` at `8f65da3`; no matching issue or pull request was found.
