### PR TITLE
Fix listenKeys with non-string map keys

### DIFF
--- a/listen-keys/index.js
+++ b/listen-keys/index.js
@@ -14,7 +14,9 @@ export function listenKeys($store, keys, listener) {
               value[key] !== oldValue[key] ||
               getPath(value, key) !== getPath(oldValue, key)
           )
-        : (keysSet.has(changed) || keysSet.has(changed.split(/\.|\[/)[0]))
+        : (keysSet.has(changed) ||
+          (typeof changed === 'string' &&
+            keysSet.has(changed.split(/\.|\[/)[0])))
     ) {
       listener(value, oldValue, changed)
     }

--- a/listen-keys/index.test.ts
+++ b/listen-keys/index.test.ts
@@ -122,6 +122,24 @@ test('filters by key when a keyed notification carries no old value', () => {
   deepStrictEqual(events, ['1 undefined a'])
 })
 
+test('ignores unrelated symbol keys', () => {
+  let unrelated = Symbol('unrelated')
+  let $store = map({ [unrelated]: 1, watched: 1 })
+  let calls = 0
+  let symbolCalls = 0
+
+  listenKeys($store, ['watched'], () => {
+    calls += 1
+  })
+  listenKeys($store, [unrelated], () => {
+    symbolCalls += 1
+  })
+
+  $store.setKey(unrelated, 2)
+  equal(calls, 0)
+  equal(symbolCalls, 1)
+})
+
 test('can subscribe to changes and call listener immediately', () => {
   let events: string[] = []
   let $store = map({ a: 1, b: 1 })


### PR DESCRIPTION
`listenKeys` accepts the same key types as a map store, but an unrelated symbol-key update currently reaches `changed.split(...)` and throws.

This keeps exact-key matching for all key types and only performs deep-path prefix parsing for string keys. The regression also verifies that a watched symbol key still fires normally.

Tests:

- `pnpm bnt -t 'unrelated symbol' listen-keys/index.test.ts`
- `pnpm test`
- `git diff --check`

All passed. The full suite reports 65 tests and the Popular Set remains within its 912 B size limit.
