### PR TITLE
fix(deep-map): use Object.is for key updates

### DIFF
--- a/deep-map/index.js
+++ b/deep-map/index.js
@@ -15,7 +15,7 @@ export const deepMap = (initial = {}) => {
 
   let $deepMap = atom(initial)
   $deepMap.setKey = (key, value) => {
-    if (getPath($deepMap.value, key) !== value) {
+    if (!Object.is(getPath($deepMap.value, key), value)) {
       let oldValue = $deepMap.value
       $deepMap.value = setPath($deepMap.value, key, value)
       $deepMap.notify(oldValue, key)

--- a/deep-map/index.test.ts
+++ b/deep-map/index.test.ts
@@ -271,6 +271,27 @@ test('does not call listeners on no changes', () => {
   deepStrictEqual(changes, [undefined])
 })
 
+test('compares deep key values with Object.is', () => {
+  let changes: string[] = []
+  let $store = deepMap({ value: NaN })
+
+  $store.listen(value => {
+    if (Object.is(value.value, -0)) {
+      changes.push('negative zero')
+    } else if (Object.is(value.value, 0)) {
+      changes.push('positive zero')
+    } else {
+      changes.push('NaN')
+    }
+  })
+
+  $store.setKey('value', NaN)
+  $store.setKey('value', -0)
+  $store.setKey('value', 0)
+
+  deepStrictEqual(changes, ['negative zero', 'positive zero'])
+})
+
 test('changes value object reference', () => {
   let $store = deepMap({ a: 0 })
 


### PR DESCRIPTION
## Problem

`deepMap.setKey()` uses strict inequality to decide whether a nested value changed. This makes `NaN` notify listeners even when it is written to an existing `NaN`, while a `-0` to `+0` update is treated as unchanged.

For example, a `deepMap({ value: NaN })` store currently reports `["NaN", "negative zero"]` after writes of `NaN`, `-0`, and `0`; the expected notifications are `["negative zero", "positive zero"]`.

## Root cause and solution

`atom()` and `map().eqKey` use `Object.is` by default, but `deepMap.setKey()` still used `!==`. This change uses `Object.is` for the deep-key comparison so all store helpers follow the same equality semantics.

## Tests

- `pnpm test`
- Direct regression probe for `NaN` and signed-zero writes

All checks passed: 67 tests, 100% line coverage, 99.57% branch coverage, lint, types, size, and synchronized-size checks.

The change is limited to one production line and one regression test; no dependencies or public API shapes changed.
